### PR TITLE
Hide "CLEAR ALL" button in Custom Select under certain conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hunar.ai/hunar-design-system",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Hunar's Design System",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hunar.ai/hunar-design-system",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Hunar's Design System",
   "repository": {
     "type": "git",

--- a/src/components/CustomSelect/CustomSelect.stories.tsx
+++ b/src/components/CustomSelect/CustomSelect.stories.tsx
@@ -9,11 +9,11 @@ import { HelperText } from '@/components/HelperText';
 import { CustomSelect, CustomSelectProps } from './CustomSelect';
 
 import { FIELD_SIZE } from '@/Enum';
-import { Options } from '@/interfaces';
+import { OptionsProps } from '@/interfaces';
 
 const onChange = action('change');
 
-const options: Options = [
+const options: OptionsProps = [
     { label: 'The Shawshank Redemption', value: 'THE_SHAWSHANK_REDEMPTION' },
     { label: 'The Godfather', value: 'THE_GODFATHER' },
     { label: 'The Godfather: Part II', value: 'THE_GODFATHER_PART_II' },
@@ -26,7 +26,7 @@ const options: Options = [
     { label: 'The Matrix', value: 'THE_MATRIX' }
 ];
 
-const disabledOptions: Options = [options[1], options[3], options[4]];
+const disabledOptions: OptionsProps = [options[1], options[3], options[4]];
 const noClearAllOptions = options.slice(0, 4);
 
 const ControlledCustomSelect = ({
@@ -138,7 +138,7 @@ const meta = {
     argTypes: {
         value: {
             table: {
-                type: { summary: `Option | Options | null` }
+                type: { summary: `OptionProps | OptionsProps | null` }
             }
         },
         size: {

--- a/src/components/CustomSelect/CustomSelect.stories.tsx
+++ b/src/components/CustomSelect/CustomSelect.stories.tsx
@@ -27,6 +27,7 @@ const options: Options = [
 ];
 
 const disabledOptions: Options = [options[1], options[3], options[4]];
+const noClearAllOptions = options.slice(0, 4);
 
 const ControlledCustomSelect = ({
     value,
@@ -97,7 +98,15 @@ const CustomSelectStates = (props: CustomSelectProps) => {
                 sectionTitle="No Search Bar"
                 {...props}
                 name="noSearchBar"
+                sectionDescription="Search Bar is only shown when there are more than 2 options"
                 options={[options[0], options[1]]}
+            />
+            <CustomSelectSection
+                sectionTitle="No Clear All Button"
+                sectionDescription="Clear All button is not shown when there are less than 5 options"
+                {...props}
+                name="noClearAll"
+                options={noClearAllOptions}
             />
             <CustomSelectSection
                 sectionTitle="Required"

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -22,15 +22,15 @@ import { CustomSelectNoOptionsText } from './CustomSelectNoOptionsText';
 import { useHelper } from '@/hooks/useHelper';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
-import type { Option, Options } from '@/interfaces';
+import type { OptionProps, OptionsProps } from '@/interfaces';
 import { FIELD_SIZE } from '@/Enum';
 import { BACKDROP_BG_COLOR } from '@/Constants';
 
 export interface CustomSelectProps {
     label: string;
     name: string;
-    options: Options;
-    value: Option | Options | null;
+    options: OptionsProps;
+    value: OptionProps | OptionsProps | null;
     id?: string;
     size?: FIELD_SIZE;
     multiple?: boolean;
@@ -39,9 +39,9 @@ export interface CustomSelectProps {
     error?: boolean;
     helperText?: React.ReactNode;
     optionsHeaderTitle?: string;
-    disabledOptions?: Options;
+    disabledOptions?: OptionsProps;
     primaryColor?: string;
-    onChange: (_: Option | Options | null) => void;
+    onChange: (_: OptionProps | OptionsProps | null) => void;
 }
 
 export const CustomSelect = ({
@@ -176,7 +176,7 @@ export const CustomSelect = ({
     );
 
     const isOptionDisabled = React.useCallback(
-        (option: Option) => {
+        (option: OptionProps) => {
             return !!disabledOptions.find(
                 element => element.value === option.value
             );
@@ -185,7 +185,7 @@ export const CustomSelect = ({
     );
 
     const onOptionClick = React.useCallback(
-        (option: Option) => {
+        (option: OptionProps) => {
             setSelectedValue(prevSelectedValue => {
                 if (multiple) {
                     const optionIndex = prevSelectedValue.indexOf(option.value);

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -108,7 +108,7 @@ export const CustomSelect = ({
             sx: {
                 '.MuiMenu-paper': isMobile ? { width: '100%' } : {},
                 '.MuiMenu-list': { py: 0 },
-                '.MuiModal-backdrop': {
+                '.MuiBackdrop-root': {
                     bgcolor: isMobile ? BACKDROP_BG_COLOR : undefined
                 }
             }

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -76,6 +76,10 @@ export const CustomSelect = ({
         React.useState(initialSelectedValue);
     const [search, setSearch] = React.useState('');
 
+    React.useEffect(() => {
+        setSelectedValue(initialSelectedValue);
+    }, [initialSelectedValue]);
+
     const valueToLabelMap = React.useMemo(() => {
         return getValueToLabelMap(options);
     }, [options, getValueToLabelMap]);

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -286,7 +286,9 @@ export const CustomSelect = ({
                 })}
                 {!filteredOptions.length && <CustomSelectNoOptionsText />}
                 <CustomSelectFooter
-                    hasOptions={!!options.length}
+                    optionsLength={options.length}
+                    isMultiple={multiple}
+                    isRequired={required}
                     primaryColor={selectedPrimaryColor}
                     onClearClick={onClearClick}
                     onConfirmClick={onConfirmClick}

--- a/src/components/CustomSelect/CustomSelectFooter.tsx
+++ b/src/components/CustomSelect/CustomSelectFooter.tsx
@@ -5,6 +5,8 @@ import tinycolor from 'tinycolor2';
 import { Button, Grid, useTheme } from '@mui/material';
 import { grey } from '@mui/material/colors';
 
+const CLEAR_ALL_VISIBLE_LIMIT = 5;
+
 interface CustomSelectFooterProps {
     optionsLength: number;
     isMultiple: boolean;
@@ -50,7 +52,7 @@ export const CustomSelectFooter = ({
     const hasOptions = React.useMemo(() => optionsLength > 0, [optionsLength]);
 
     const isClearAllVisible = React.useMemo(() => {
-        if (optionsLength < 5) {
+        if (optionsLength < CLEAR_ALL_VISIBLE_LIMIT) {
             return false;
         }
 

--- a/src/components/CustomSelect/CustomSelectFooter.tsx
+++ b/src/components/CustomSelect/CustomSelectFooter.tsx
@@ -6,14 +6,18 @@ import { Button, Grid, useTheme } from '@mui/material';
 import { grey } from '@mui/material/colors';
 
 interface CustomSelectFooterProps {
-    hasOptions: boolean;
+    optionsLength: number;
+    isMultiple: boolean;
+    isRequired: boolean;
     primaryColor: string;
     onClearClick: VoidFunction;
     onConfirmClick: VoidFunction;
 }
 
 export const CustomSelectFooter = ({
-    hasOptions,
+    optionsLength,
+    isMultiple,
+    isRequired,
     primaryColor,
     onClearClick,
     onConfirmClick
@@ -43,10 +47,20 @@ export const CustomSelectFooter = ({
         };
     }, [primaryColor, theme.palette]);
 
+    const hasOptions = React.useMemo(() => optionsLength > 0, [optionsLength]);
+
+    const isClearAllVisible = React.useMemo(() => {
+        if (optionsLength < 5) {
+            return false;
+        }
+
+        return isMultiple || !isRequired;
+    }, [isMultiple, optionsLength, isRequired]);
+
     return (
         <Grid
             container
-            justifyContent="space-between"
+            justifyContent={isClearAllVisible ? 'space-between' : 'end'}
             alignItems="center"
             position="sticky"
             bottom={0}
@@ -56,24 +70,20 @@ export const CustomSelectFooter = ({
             py={1.5}
             borderTop={hasOptions ? `1px solid ${grey[200]}` : undefined}
         >
+            {isClearAllVisible && (
+                <Button size="large" sx={textButtonSx} onClick={onClearClick}>
+                    CLEAR ALL
+                </Button>
+            )}
             {hasOptions && (
-                <>
-                    <Button
-                        size="large"
-                        sx={textButtonSx}
-                        onClick={onClearClick}
-                    >
-                        CLEAR ALL
-                    </Button>
-                    <Button
-                        size="large"
-                        variant="contained"
-                        sx={containedButtonSx}
-                        onClick={onConfirmClick}
-                    >
-                        CONFIRM
-                    </Button>
-                </>
+                <Button
+                    size="large"
+                    variant="contained"
+                    sx={containedButtonSx}
+                    onClick={onConfirmClick}
+                >
+                    CONFIRM
+                </Button>
             )}
         </Grid>
     );

--- a/src/components/CustomSelect/CustomSelectOption.tsx
+++ b/src/components/CustomSelect/CustomSelectOption.tsx
@@ -4,10 +4,10 @@ import tinycolor from 'tinycolor2';
 
 import { Checkbox, Grid, Radio, type SxProps, Typography } from '@mui/material';
 
-import type { Option } from '@/interfaces';
+import type { OptionProps } from '@/interfaces';
 
 interface CustomSelectOptionProps {
-    option: Option;
+    option: OptionProps;
     multiple: boolean;
     isSelected: boolean;
     primaryColor: string;

--- a/src/hooks/useHelper.ts
+++ b/src/hooks/useHelper.ts
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import type { Option, Options } from '@/interfaces';
+import type { OptionProps, OptionsProps } from '@/interfaces';
 
 export const useHelper = () => {
     const getValueToLabelMap = React.useCallback(
-        (options: Options): { [key: string]: string } => {
+        (options: OptionsProps): { [key: string]: string } => {
             const optionsMap = options.reduce(
-                (acc: { [key: string]: string }, key: Option) => {
+                (acc: { [key: string]: string }, key: OptionProps) => {
                     acc = {
                         ...acc,
                         [key.value]: key.label

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,1 +1,1 @@
-export type { Option, Options } from './option.interface';
+export type { OptionProps, OptionsProps } from './option.interface';

--- a/src/interfaces/option.interface.ts
+++ b/src/interfaces/option.interface.ts
@@ -1,8 +1,8 @@
-export interface Option {
+export interface OptionProps {
     value: string;
     label: string;
     labelHelperText?: string;
     state?: string;
 }
 
-export type Options = Option[];
+export type OptionsProps = OptionProps[];


### PR DESCRIPTION
This PR addresses part of [OM-3339](https://hunar.atlassian.net/browse/OM-3339)

## Feature:

1. Hide "CLEAR ALL" button in `CustomSelect` component when
    1. there are less than 5 options
    2. when `CustomSelect` is a single select and it a required field
2. Add a "No Clear All Button" section in Custom Select Story
3. The following bugs are fixed
  a. backdrop bg color is not being applied in project with `@mui/material` version lower than `5.12.0`
  b. `selectedValue` should change when `value` is changed 

## Storybook Link:

[Storybook link with changes](https://hide-clearall--666ac08efe69dd9c59a1e4c6.chromatic.com/?path=/story/components-customselect--single-select)