### PR TITLE
Fix `.mjs` error when using package in webpack projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hunar.ai/hunar-design-system",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Hunar's Design System",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,22 +13,21 @@
   "homepage": "https://github.com/Hunar-ai/hunar-design-system#readme",
   "license": "MIT",
   "private": false,
-  "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "module": "./dist/index.mjs",
+      "module": "./dist/index.esm.js",
       "import": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.mjs"
+        "default": "./dist/index.esm.js"
       },
       "require": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       },
-      "default": "./dist/index.mjs"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -28,7 +28,7 @@ export default [
       },
       {
         dir: outputDir,
-        entryFileNames: "[name].mjs",
+        entryFileNames: "[name].esm.js",
         format: "es",
         preserveModules: true,
         preserveModulesRoot: "src",


### PR DESCRIPTION
This PR changes build config in order to fix `.mjs` error (👇 ) when using package in webpack projects

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/1e5e372e-6915-43ee-bb1d-170dc5b5a77b">

## Technical:
- Change the extension of the esm build output from `.mjs` to `.esm.js`
- Change the default type of package from esm to commonjs (`"type": "module"` is removed from `package.json`)

## References:
- [webpack issue](https://github.com/webpack/webpack/issues/11467)
- Solution Reference: [React Query](https://github.com/TanStack/query/blob/v4/packages/react-query/package.json#L19)