### PR TITLE
Custom Select bugfix: Break option with very long text without space into multiple lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hunar.ai/hunar-design-system",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Hunar's Design System",
   "repository": {
     "type": "git",

--- a/src/components/CustomSelect/CustomSelect.stories.tsx
+++ b/src/components/CustomSelect/CustomSelect.stories.tsx
@@ -14,6 +14,10 @@ import { OptionsProps } from '@/interfaces';
 const onChange = action('change');
 
 const options: OptionsProps = [
+    {
+        label: 'VeryLongOptionWithoutAnySpaceVeryLongOptionWithoutAnySpace',
+        value: 'VERY_LONG_OPTION_WITHOUT_ANY_SPACE'
+    },
     { label: 'The Shawshank Redemption', value: 'THE_SHAWSHANK_REDEMPTION' },
     { label: 'The Godfather', value: 'THE_GODFATHER' },
     { label: 'The Godfather: Part II', value: 'THE_GODFATHER_PART_II' },

--- a/src/components/CustomSelect/CustomSelectOption.tsx
+++ b/src/components/CustomSelect/CustomSelectOption.tsx
@@ -42,7 +42,7 @@ export const CustomSelectOption = ({
                     <Radio checked={isSelected} sx={sx} size="small" />
                 )}
             </Grid>
-            <Grid item xs sx={{ textWrap: 'wrap' }}>
+            <Grid item xs sx={{ textWrap: 'wrap', wordBreak: 'break-all' }}>
                 <Typography>{option.label}</Typography>
             </Grid>
         </Grid>


### PR DESCRIPTION
This PR fixes a bug in Custom Select

## Features:
- Break option with very long text without space into multiple lines

**Before bugfix**
<img width="319" alt="image" src="https://github.com/user-attachments/assets/a60f9df2-235d-4a66-9f24-5cd3ed4eaaea">

**After bugfix**
<img width="320" alt="image" src="https://github.com/user-attachments/assets/032b89ca-f663-4e21-b897-f369174ddf81">

## Reference:
- [Storybook Link](https://custom-select-bugfix--666ac08efe69dd9c59a1e4c6.chromatic.com/?path=/story/components-customselect--playground&globals=viewport:mobile1)
