### PR TITLE
OM-3530: Add Text Input fields for Chatbot

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "@mui/base": "^5.0.0-beta.40",
     "@mui/material": "^5.8.7",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-number-format": "^5.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
+    "@mui/base": "^5.0.0-beta.40",
     "@mui/material": "^5.8.7",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/src/Enum.ts
+++ b/src/Enum.ts
@@ -31,3 +31,9 @@ export enum POPOVER_ORIGIN {
     BOTTOM_CENTER = 'bottom_center',
     BOTTOM_RIGHT = 'bottom_right'
 }
+
+export enum TEXT_INPUT_VARIANT {
+    TEXT_FIELD = 'TEXT_FIELD',
+    TEXT_AREA = 'TEXT_AREA',
+    CURRENCY = 'CURRENCY'
+}

--- a/src/components/BrandedButton.tsx
+++ b/src/components/BrandedButton.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+import tinycolor from 'tinycolor2';
+
+import {
+    Button,
+    type ButtonProps,
+    useTheme,
+    type SxProps
+} from '@mui/material';
+
+interface BrandedButtonProps extends ButtonProps {
+    primaryColor: string;
+}
+
+export const BrandedButton = ({
+    primaryColor,
+    variant,
+    sx = {},
+    ...restProps
+}: BrandedButtonProps) => {
+    const theme = useTheme();
+
+    const textButtonSx: SxProps = React.useMemo(() => {
+        const hoverBGColor = tinycolor(primaryColor).setAlpha(0.04).toString();
+        return {
+            color: primaryColor,
+            '&:hover': {
+                backgroundColor: hoverBGColor
+            }
+        };
+    }, [primaryColor]);
+
+    const outlinedButtonSx: SxProps = React.useMemo(() => {
+        const hoverBGColor = tinycolor(primaryColor).setAlpha(0.04).toString();
+        const borderColor = tinycolor(primaryColor).setAlpha(0.5).toString();
+
+        return {
+            color: primaryColor,
+            border: `1px solid ${borderColor}`,
+            '&:hover': {
+                backgroundColor: hoverBGColor,
+                border: `1px solid ${primaryColor}`
+            }
+        };
+    }, [primaryColor]);
+
+    const containedButtonSx: SxProps = React.useMemo(() => {
+        const hoverBGColor = tinycolor
+            ? tinycolor(primaryColor).darken(4).toString()
+            : primaryColor;
+        return {
+            color: theme.palette.getContrastText(primaryColor),
+            backgroundColor: primaryColor,
+            '&:hover': {
+                backgroundColor: hoverBGColor
+            }
+        };
+    }, [primaryColor, theme.palette]);
+
+    const primaryColorSx: SxProps = React.useMemo(() => {
+        switch (variant) {
+            case 'contained':
+                return containedButtonSx;
+            case 'outlined':
+                return outlinedButtonSx;
+            case 'text':
+                return textButtonSx;
+            default:
+                return containedButtonSx;
+        }
+    }, [containedButtonSx, outlinedButtonSx, textButtonSx, variant]);
+
+    return (
+        <Button
+            {...restProps}
+            variant={variant}
+            sx={{ ...primaryColorSx, ...sx }}
+        />
+    );
+};

--- a/src/components/ChatTextInput/ChatTextInput.stories.tsx
+++ b/src/components/ChatTextInput/ChatTextInput.stories.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import { StorySection } from '@/components/storybook';
+import { ChatTextInput, ChatTextInputProps } from './ChatTextInput';
+
+import { BUTTON_SIZE, TEXT_INPUT_VARIANT, FIELD_SIZE } from '@/Enum';
+
+const onSave = action('save');
+
+const ControlledChatTextInput = ({ value, ...props }: ChatTextInputProps) => {
+    const [valueState, setValueState] = React.useState(value);
+
+    return (
+        <ChatTextInput
+            {...props}
+            value={valueState}
+            onSave={modifiedValue => {
+                onSave(modifiedValue);
+                setValueState(modifiedValue);
+            }}
+        />
+    );
+};
+
+interface ChatTextInputSectionProps extends ChatTextInputProps {
+    sectionTitle: string;
+    sectionDescription?: string;
+}
+
+const ChatTextInputSection = ({
+    sectionTitle,
+    sectionDescription,
+    ...props
+}: ChatTextInputSectionProps) => {
+    return (
+        <StorySection title={sectionTitle} description={sectionDescription}>
+            <ControlledChatTextInput {...props} />
+        </StorySection>
+    );
+};
+
+const ChatTextInputStates = (props: ChatTextInputProps) => {
+    return (
+        <>
+            <ChatTextInputSection
+                sectionTitle="Default"
+                {...props}
+                name="default"
+            />
+            <ChatTextInputSection
+                sectionTitle="Filled value"
+                sectionDescription="Click on edit icon to change the filled value"
+                {...props}
+                value="1234"
+            />
+            <ChatTextInputSection sectionTitle="Disabled" {...props} disabled />
+            <ChatTextInputSection sectionTitle="Required" {...props} required />
+            <ChatTextInputSection
+                sectionTitle="Placeholder"
+                sectionDescription="Try different value of `placeholder` from controls"
+                {...props}
+                label=""
+            />
+            <ChatTextInputSection
+                sectionTitle="Field Size: Medium"
+                {...props}
+                fieldSize={FIELD_SIZE.medium}
+            />
+            <ChatTextInputSection
+                sectionTitle="Button Size: Medium"
+                {...props}
+                buttonSize={BUTTON_SIZE.medium}
+            />
+            <ChatTextInputSection
+                sectionTitle="Button Size: Small"
+                {...props}
+                buttonSize={BUTTON_SIZE.small}
+            />
+            <ChatTextInputSection
+                sectionTitle="HelperText"
+                {...props}
+                helperMsg="This is helper text"
+            />
+            <ChatTextInputSection
+                sectionTitle="With validation"
+                sectionDescription="Enter text longer than 4 characters to see error"
+                {...props}
+                handleIsValidCheck={inputValue => inputValue.length > 4}
+                errorMsg="Must be smaller than 5 characters"
+            />
+            <ChatTextInputSection
+                sectionTitle="With validation"
+                sectionDescription="Enter text longer than 5 characters to remove error"
+                {...props}
+                handleIsValidCheck={inputValue => inputValue.length < 5}
+                errorMsg="Must be longer than 5 characters"
+            />
+        </>
+    );
+};
+
+const meta = {
+    title: 'Components/ChatTextInput',
+    component: ChatTextInput,
+    parameters: { controls: { expanded: true } },
+    argTypes: {
+        fieldSize: {
+            control: 'select',
+            options: [FIELD_SIZE.small, FIELD_SIZE.medium]
+        },
+        buttonSize: {
+            control: 'select',
+            options: [BUTTON_SIZE.small, BUTTON_SIZE.medium, BUTTON_SIZE.large]
+        },
+        variant: {
+            control: 'select',
+            options: [
+                TEXT_INPUT_VARIANT.TEXT_FIELD,
+                TEXT_INPUT_VARIANT.TEXT_AREA,
+                TEXT_INPUT_VARIANT.CURRENCY
+            ]
+        },
+        textFieldType: {
+            table: {
+                type: { summary: `React.HTMLInputTypeAttribute` }
+            },
+            control: 'text'
+        }
+    },
+    args: { value: '', onSave }
+} satisfies Meta<typeof ChatTextInput>;
+
+export default meta;
+
+type StoryProps = StoryObj<typeof ChatTextInput>;
+
+export const Playground: StoryProps = {
+    render: function Playground(props) {
+        return (
+            <ChatTextInputSection
+                sectionTitle=""
+                // eslint-disable-next-line max-len
+                sectionDescription={`Change various props in the "Controls" panel to see how they change behavior of the component`}
+                {...props}
+            />
+        );
+    }
+};
+
+const variantAllowedControls = [
+    'name',
+    'id',
+    'label',
+    'primaryColor',
+    'placeholder',
+    'textFieldType',
+    'inputFieldSx',
+    'previewSx'
+];
+
+export const TextField: StoryProps = {
+    parameters: {
+        controls: {
+            include: variantAllowedControls
+        }
+    },
+    args: { variant: TEXT_INPUT_VARIANT.TEXT_FIELD, label: 'TextField' },
+    render: props => <ChatTextInputStates {...props} />
+};
+
+export const TextArea: StoryProps = {
+    parameters: {
+        controls: {
+            include: variantAllowedControls
+        }
+    },
+    args: { variant: TEXT_INPUT_VARIANT.TEXT_AREA, label: 'TextArea' },
+    render: props => <ChatTextInputStates {...props} />
+};
+
+export const CurrencyField: StoryProps = {
+    parameters: {
+        controls: {
+            include: variantAllowedControls
+        }
+    },
+    args: { variant: TEXT_INPUT_VARIANT.CURRENCY, label: 'Currency' },
+    render: props => <ChatTextInputStates {...props} />
+};

--- a/src/components/ChatTextInput/ChatTextInput.tsx
+++ b/src/components/ChatTextInput/ChatTextInput.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+
+import { Grid, type SxProps, useTheme } from '@mui/material';
+
+import { ChatTextInputPreview } from './ChatTextInputPreview';
+import { ChatTextInputCtaList } from './ChatTextInputCtaList';
+import { ChatTextInputField } from './ChatTextInputField';
+
+import { BUTTON_SIZE, TEXT_INPUT_VARIANT, FIELD_SIZE } from '@/Enum';
+
+export interface ChatTextInputProps {
+    name: string;
+    value: string;
+    id?: string;
+    label?: string;
+    required?: boolean;
+    disabled?: boolean;
+    primaryColor?: string;
+    variant?: TEXT_INPUT_VARIANT;
+    placeholder?: string;
+    fieldSize?: FIELD_SIZE;
+    buttonSize?: BUTTON_SIZE;
+    errorMsg?: string;
+    helperMsg?: string;
+    textFieldType?: React.HTMLInputTypeAttribute;
+    inputFieldSx?: SxProps;
+    previewSx?: SxProps;
+    onSave: (_: string) => void;
+    handleIsValidCheck?: (_: string) => boolean;
+}
+
+export const ChatTextInput = ({
+    name,
+    value,
+    id = '',
+    label = '',
+    required = false,
+    disabled = false,
+    primaryColor = undefined,
+    variant = TEXT_INPUT_VARIANT.TEXT_FIELD,
+    placeholder = 'Type here...',
+    fieldSize = FIELD_SIZE.small,
+    buttonSize = BUTTON_SIZE.large,
+    errorMsg = '',
+    helperMsg = '',
+    textFieldType = 'text',
+    inputFieldSx = {},
+    previewSx = {},
+    onSave,
+    handleIsValidCheck = undefined
+}: ChatTextInputProps) => {
+    const theme = useTheme();
+    const [editedValue, setEditedValue] = React.useState(value);
+    const [isEditing, setIsEditing] = React.useState(false);
+
+    const hasErrors = React.useMemo(() => {
+        return handleIsValidCheck ? handleIsValidCheck(editedValue) : false;
+    }, [editedValue, handleIsValidCheck]);
+
+    const selectedPrimaryColor = React.useMemo(
+        () => primaryColor || theme.palette.primary.main,
+        [primaryColor, theme.palette.primary.main]
+    );
+
+    const onFieldChange = (e: React.BaseSyntheticEvent) => {
+        setEditedValue(e.target.value);
+    };
+
+    const onFocus = () => setIsEditing(true);
+
+    const onBlur = () => {
+        if (!value && !editedValue) {
+            setIsEditing(false);
+        }
+    };
+
+    const handleCancelClick = () => {
+        setEditedValue(value);
+        setIsEditing(false);
+    };
+
+    const handleSaveClick = () => {
+        onSave(editedValue);
+        setIsEditing(false);
+    };
+
+    return (
+        <Grid container rowGap={0.5} justifyContent="end">
+            {!value || isEditing ? (
+                <ChatTextInputField
+                    id={id}
+                    name={name}
+                    label={label}
+                    variant={variant}
+                    required={required}
+                    disabled={disabled}
+                    primaryColor={selectedPrimaryColor}
+                    value={editedValue}
+                    fieldSize={fieldSize}
+                    placeholder={placeholder}
+                    error={hasErrors}
+                    errorMsg={errorMsg}
+                    helperMsg={helperMsg}
+                    textFieldType={textFieldType}
+                    inputFieldSx={inputFieldSx}
+                    onFieldChange={onFieldChange}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                />
+            ) : (
+                <ChatTextInputPreview
+                    value={value}
+                    fieldSize={fieldSize}
+                    sx={previewSx}
+                    onEditClick={() => setIsEditing(true)}
+                />
+            )}
+            {isEditing && (
+                <ChatTextInputCtaList
+                    buttonSize={buttonSize}
+                    primaryColor={selectedPrimaryColor}
+                    isCancelDisabled={!editedValue || hasErrors}
+                    isSaveDisabled={!editedValue || hasErrors}
+                    onCancelClick={handleCancelClick}
+                    onSaveClick={handleSaveClick}
+                />
+            )}
+        </Grid>
+    );
+};

--- a/src/components/ChatTextInput/ChatTextInputCtaList.tsx
+++ b/src/components/ChatTextInput/ChatTextInputCtaList.tsx
@@ -1,0 +1,46 @@
+import { Grid } from '@mui/material';
+
+import { BrandedButton } from '@/components/BrandedButton';
+
+import { BUTTON_SIZE } from '@/Enum';
+
+interface ChatTextInputCtaListProps {
+    buttonSize: BUTTON_SIZE;
+    primaryColor: string;
+    isCancelDisabled: boolean;
+    isSaveDisabled: boolean;
+    onCancelClick: VoidFunction;
+    onSaveClick: VoidFunction;
+}
+
+export const ChatTextInputCtaList = ({
+    buttonSize,
+    primaryColor,
+    isCancelDisabled,
+    isSaveDisabled,
+    onCancelClick,
+    onSaveClick
+}: ChatTextInputCtaListProps) => {
+    return (
+        <Grid item xs={12} display="flex" justifyContent="end" columnGap={1.5}>
+            <BrandedButton
+                variant="outlined"
+                size={buttonSize}
+                primaryColor={primaryColor}
+                onClick={onCancelClick}
+                disabled={isCancelDisabled}
+            >
+                CANCEL
+            </BrandedButton>
+            <BrandedButton
+                variant="contained"
+                size={buttonSize}
+                primaryColor={primaryColor}
+                onClick={onSaveClick}
+                disabled={isSaveDisabled}
+            >
+                SAVE
+            </BrandedButton>
+        </Grid>
+    );
+};

--- a/src/components/ChatTextInput/ChatTextInputField.tsx
+++ b/src/components/ChatTextInput/ChatTextInputField.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+
+import { type SxProps, TextField } from '@mui/material';
+
+import { CurrencyField } from '@/components/CurrencyField';
+import { HelperText } from '@/components/HelperText';
+import { TextArea } from '@/components/TextArea';
+
+import { FIELD_SIZE, TEXT_INPUT_VARIANT } from '@/Enum';
+
+interface ChatTextInputFieldProps {
+    name: string;
+    value: string;
+    variant: TEXT_INPUT_VARIANT;
+    id: string;
+    label: string;
+    required: boolean;
+    disabled: boolean;
+    primaryColor: string;
+    placeholder: string;
+    fieldSize: FIELD_SIZE;
+    error: boolean;
+    errorMsg: string;
+    helperMsg: string;
+    textFieldType: React.HTMLInputTypeAttribute;
+    inputFieldSx: SxProps;
+    onFieldChange: (_: React.BaseSyntheticEvent) => void;
+    onFocus: VoidFunction;
+    onBlur: VoidFunction;
+}
+
+export const ChatTextInputField = ({
+    name,
+    value,
+    variant,
+    id,
+    label,
+    required,
+    disabled,
+    primaryColor,
+    placeholder,
+    fieldSize,
+    error,
+    errorMsg,
+    helperMsg,
+    textFieldType,
+    inputFieldSx,
+    onFieldChange,
+    onFocus,
+    onBlur
+}: ChatTextInputFieldProps) => {
+    const borderColorSx = React.useMemo(() => {
+        return {
+            '& .MuiInputBase-root.Mui-focused fieldset': {
+                borderColor: error ? undefined : primaryColor
+            }
+        };
+    }, [error, primaryColor]);
+
+    switch (variant) {
+        case TEXT_INPUT_VARIANT.TEXT_AREA:
+            return (
+                <TextArea
+                    fullWidth
+                    name={name}
+                    id={id}
+                    required={required}
+                    disabled={disabled}
+                    primaryColor={primaryColor}
+                    value={value}
+                    size={fieldSize}
+                    placeholder={placeholder}
+                    sx={inputFieldSx}
+                    onChange={onFieldChange}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                    error={error}
+                    helperText={
+                        <HelperText
+                            hasError={error}
+                            errorMsg={errorMsg}
+                            msg={helperMsg}
+                        />
+                    }
+                />
+            );
+        case TEXT_INPUT_VARIANT.CURRENCY:
+            return (
+                <CurrencyField
+                    fullWidth
+                    name={name}
+                    id={id}
+                    label={label}
+                    required={required}
+                    disabled={disabled}
+                    sx={{ ...borderColorSx, ...inputFieldSx }}
+                    value={value}
+                    size={fieldSize}
+                    placeholder={placeholder}
+                    onChange={onFieldChange}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                    error={error}
+                    helperText={
+                        <HelperText
+                            hasError={error}
+                            errorMsg={errorMsg}
+                            msg={helperMsg}
+                        />
+                    }
+                />
+            );
+        case TEXT_INPUT_VARIANT.TEXT_FIELD:
+        default:
+            return (
+                <TextField
+                    type={textFieldType}
+                    fullWidth
+                    autoComplete="off"
+                    name={name}
+                    id={id}
+                    label={label}
+                    required={required}
+                    disabled={disabled}
+                    value={value}
+                    sx={{ ...borderColorSx, ...inputFieldSx }}
+                    size={fieldSize}
+                    placeholder={placeholder}
+                    onChange={onFieldChange}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
+                    error={error}
+                    helperText={
+                        <HelperText
+                            hasError={error}
+                            errorMsg={errorMsg}
+                            msg={helperMsg}
+                        />
+                    }
+                />
+            );
+    }
+};

--- a/src/components/ChatTextInput/ChatTextInputPreview.tsx
+++ b/src/components/ChatTextInput/ChatTextInputPreview.tsx
@@ -1,0 +1,44 @@
+import { Grid, IconButton, SxProps, Typography } from '@mui/material';
+import { EditOutlined as EditOutlinedIcon } from '@mui/icons-material';
+import { grey } from '@mui/material/colors';
+
+import { FIELD_SIZE } from '@/Enum';
+
+interface ChatTextInputPreviewProps {
+    value: string;
+    fieldSize: FIELD_SIZE;
+    sx?: SxProps;
+    onEditClick: VoidFunction;
+}
+
+export const ChatTextInputPreview = ({
+    value,
+    fieldSize,
+    sx = {},
+    onEditClick
+}: ChatTextInputPreviewProps) => {
+    return (
+        <Grid
+            item
+            display="flex"
+            alignItems="center"
+            columnGap={1}
+            sx={{ outline: `1px solid ${grey[400]}`, ...sx }}
+            borderRadius={1}
+            px={1.75}
+            py={fieldSize === FIELD_SIZE.small ? 0 : 1}
+            maxWidth="100%"
+        >
+            <Typography
+                whiteSpace="nowrap"
+                overflow="hidden"
+                textOverflow="ellipsis"
+            >
+                {value}
+            </Typography>
+            <IconButton sx={{ p: 1.25, mr: -1.25 }} onClick={onEditClick}>
+                <EditOutlinedIcon fontSize="small" />
+            </IconButton>
+        </Grid>
+    );
+};

--- a/src/components/ChatTextInput/index.ts
+++ b/src/components/ChatTextInput/index.ts
@@ -1,0 +1,1 @@
+export * from './ChatTextInput';

--- a/src/components/CurrencyField.tsx
+++ b/src/components/CurrencyField.tsx
@@ -1,0 +1,100 @@
+import {
+    NumericFormat,
+    type NumberFormatValues as NumberFormatValuesProps,
+    type SourceInfo as SourceInfoProps
+} from 'react-number-format';
+
+import { InputAdornment, SxProps, TextField } from '@mui/material';
+
+import { FIELD_SIZE } from '@/Enum';
+
+interface CurrencyFieldProps {
+    id: string;
+    name: string;
+    value: string | number | null;
+    label?: string;
+    required?: boolean;
+    placeholder?: string;
+    sx?: SxProps;
+    size?: FIELD_SIZE;
+    disabled?: boolean;
+    fullWidth?: boolean;
+    error?: boolean;
+    helperText?: React.ReactNode;
+    decimalScale?: number;
+    allowNegative?: boolean;
+    onChange?: (_: React.BaseSyntheticEvent) => void;
+    onFocus?: (_: React.FocusEvent<HTMLInputElement>) => void;
+    onBlur?: (_: React.FocusEvent<HTMLInputElement>) => void;
+    onClick?: (_: React.MouseEvent<HTMLInputElement>) => void;
+    handleIsValidCheck?: (_: string) => boolean;
+}
+
+export const CurrencyField = ({
+    id,
+    name,
+    value,
+    label = '',
+    placeholder = '00,00,000',
+    sx = {},
+    size = FIELD_SIZE.medium,
+    disabled = false,
+    required = false,
+    fullWidth = false,
+    error = false,
+    helperText = '',
+    decimalScale = 0,
+    allowNegative = false,
+    onChange = () => undefined,
+    onFocus = () => undefined,
+    onBlur = () => undefined,
+    onClick = () => undefined,
+    handleIsValidCheck = () => true
+}: CurrencyFieldProps) => {
+    const onValueChange = (
+        modifiedValues: NumberFormatValuesProps,
+        sourceInfo: SourceInfoProps
+    ) => {
+        if (sourceInfo.source === 'prop') return;
+
+        const event = {
+            target: { name, value: modifiedValues.value }
+        } as React.BaseSyntheticEvent;
+        onChange(event);
+    };
+
+    return (
+        <NumericFormat
+            id={id}
+            name={name}
+            label={label}
+            required={required}
+            placeholder={placeholder}
+            fullWidth={fullWidth}
+            sx={sx}
+            size={size}
+            value={`${value ?? ''}`}
+            disabled={disabled}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            onClick={onClick}
+            onValueChange={onValueChange}
+            error={error}
+            helperText={helperText}
+            customInput={TextField}
+            InputProps={{
+                startAdornment: (
+                    <InputAdornment position="start">₹</InputAdornment>
+                )
+            }}
+            isAllowed={modifiedValues =>
+                handleIsValidCheck(modifiedValues.value)
+            }
+            valueIsNumericString
+            decimalScale={decimalScale}
+            allowNegative={allowNegative}
+            thousandSeparator=","
+            thousandsGroupStyle="lakh"
+        />
+    );
+};

--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -104,7 +104,7 @@ export const TextArea = ({
                     px: '13px',
                     py: size === FIELD_SIZE.medium ? '17px' : '9px',
                     mb: '-6px',
-                    borderRadius: 4,
+                    borderRadius: 1,
                     fontSize: 16,
                     fontFamily: 'Lato',
                     letterSpacing: 'inherit',

--- a/src/components/TextArea.tsx
+++ b/src/components/TextArea.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+
+import { Box, Grid, type SxProps, Typography, useTheme } from '@mui/material';
+import { grey } from '@mui/material/colors';
+import { TextareaAutosize } from '@mui/base/TextareaAutosize';
+
+import { asteriskStyle } from '@/theme';
+import { FIELD_SIZE } from '@/Enum';
+
+interface TextAreaProps {
+    name: string;
+    value: string;
+    placeholder: string;
+    id?: string;
+    size?: FIELD_SIZE;
+    fullWidth?: boolean;
+    required?: boolean;
+    disabled?: boolean;
+    primaryColor?: string;
+    resize?: React.CSSProperties['resize'];
+    sx?: SxProps;
+    minRows?: number;
+    maxRows?: number;
+    maxLength?: number;
+    minLength?: number;
+    error?: boolean;
+    helperText?: React.ReactNode;
+    showCharHelpText?: boolean;
+    onChange: (_: React.ChangeEvent<HTMLTextAreaElement>) => void;
+    onFocus?: (_: React.FocusEvent<HTMLTextAreaElement>) => void;
+    onBlur?: (_: React.FocusEvent<HTMLTextAreaElement>) => void;
+    onClick?: (e: React.SyntheticEvent) => void;
+}
+
+export const TextArea = ({
+    name,
+    value,
+    placeholder,
+    id = '',
+    size = FIELD_SIZE.medium,
+    fullWidth = false,
+    required = false,
+    disabled = false,
+    primaryColor = undefined,
+    resize = 'both',
+    sx = {},
+    minRows = 2,
+    maxRows = 3,
+    maxLength = 200,
+    minLength = undefined,
+    error = false,
+    helperText = '',
+    showCharHelpText = false,
+    onChange,
+    onFocus,
+    onBlur,
+    onClick
+}: TextAreaProps) => {
+    const theme = useTheme();
+
+    const getHelperText = React.useCallback(() => {
+        const numberOfCharacters = value ? value.length : 0;
+        const remainingCharacters = maxLength - numberOfCharacters;
+        if (minLength && numberOfCharacters < minLength) {
+            const requiredCharacters = minLength - numberOfCharacters;
+            const textPostFix = numberOfCharacters
+                ? 'more character required'
+                : 'characters required';
+            return `${requiredCharacters} ${textPostFix}`;
+        }
+        const textPostFix = numberOfCharacters
+            ? 'characters remaining'
+            : 'characters';
+        return numberOfCharacters > 1
+            ? `${remainingCharacters} ${textPostFix}`
+            : '';
+    }, [value, maxLength, minLength]);
+
+    return (
+        <Box
+            id={id}
+            sx={{
+                position: 'relative',
+                '.textarea': {
+                    borderColor: error ? theme.palette.error.main : grey[400]
+                },
+                '.textarea:hover': {
+                    borderColor: error || disabled ? undefined : grey[900]
+                },
+                width: fullWidth ? '100%' : undefined
+            }}
+        >
+            <Box
+                component={TextareaAutosize}
+                className="textarea"
+                minRows={minRows}
+                maxRows={maxRows}
+                disabled={disabled}
+                sx={{
+                    width: fullWidth ? '100%' : '180px',
+                    outlineColor: error
+                        ? theme.palette.error.main
+                        : primaryColor,
+                    px: '13px',
+                    py: size === FIELD_SIZE.medium ? '17px' : '9px',
+                    mb: '-6px',
+                    borderRadius: 4,
+                    fontSize: 16,
+                    fontFamily: 'Lato',
+                    letterSpacing: 'inherit',
+                    resize,
+                    ...sx
+                }}
+                name={name}
+                onChange={onChange}
+                value={value}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                onClick={onClick}
+            />
+            <Typography
+                aria-hidden="true"
+                sx={{
+                    pointerEvents: 'none',
+                    userSelect: 'none',
+                    display: value ? 'none' : 'inherit',
+                    position: 'absolute',
+                    top: size === FIELD_SIZE.medium ? 12 : 4,
+                    left: 14,
+                    color: error
+                        ? theme.palette.error.main
+                        : disabled
+                        ? grey[400]
+                        : grey[500]
+                }}
+            >
+                {placeholder}
+                <Typography component="span" sx={{ ...asteriskStyle }}>{`${
+                    required ? ' *' : ''
+                }`}</Typography>
+            </Typography>
+            <Grid container justifyContent="space-between">
+                {helperText && (
+                    <Typography
+                        component="span"
+                        align="left"
+                        variant="caption"
+                        mt={size === FIELD_SIZE.medium ? '3px' : '4px'}
+                        mx="14px"
+                        color={
+                            error || maxLength - value.length < 0
+                                ? theme.palette.error.main
+                                : ''
+                        }
+                    >
+                        {helperText}
+                    </Typography>
+                )}
+                {showCharHelpText && (
+                    <Typography
+                        component="div"
+                        align="right"
+                        variant="caption"
+                        mt={size === FIELD_SIZE.medium ? '3px' : '4px'}
+                        color={
+                            maxLength - value.length < 0 ||
+                            (minLength &&
+                                value.length > 3 &&
+                                value.length < minLength)
+                                ? theme.palette.error.main
+                                : ''
+                        }
+                    >
+                        {value.length > 3 && getHelperText()}
+                    </Typography>
+                )}
+            </Grid>
+        </Box>
+    );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,3 +7,4 @@ export {
     type KebabMenuOptionProps,
     type KebabMenuProps
 } from './KebabMenu';
+export { ChatTextInput, type ChatTextInputProps } from './ChatTextInput';

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -20,34 +20,9 @@ export const theme = createTheme({
         }
     },
     components: {
-        MuiInputBase: {
-            styleOverrides: {
-                sizeSmall: {
-                    fontSize: '0.85rem',
-                    minHeight: '2.2rem !important'
-                },
-                inputSizeSmall: {
-                    height: '0.9rem !important'
-                }
-            }
-        },
-
         MuiInputLabel: {
             styleOverrides: {
-                sizeSmall: {
-                    fontSize: '0.85rem'
-                },
                 asterisk: asteriskStyle
-            }
-        },
-        MuiButton: {
-            styleOverrides: {
-                sizeMedium: {
-                    height: '2.0.85rem'
-                },
-                sizeSmall: {
-                    height: '1.8rem'
-                }
             }
         },
         MuiSelect: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6977,6 +6977,13 @@ react-is@^18.0.0, react-is@^18.2.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
+react-number-format@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-5.4.0.tgz#8c1e97add1970d1a2f372ca286bcdaa49632ba5c"
+  integrity sha512-NWdICrqLhI7rAS8yUeLVd6Wr4cN7UjJ9IBTS0f/a9i7UB4x4Ti70kGnksBtZ7o4Z7YRbvCMMR/jQmkoOBa/4fg==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-refresh@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"


### PR DESCRIPTION
This PR addresses [OM-3530](https://hunar.atlassian.net/browse/OM-3530)


## Features:

- Add `ChatTextInput` component. Support for following text inputs are added:
  - `TextField`
  - `TextArea`
  - `Currency`
- Add story for `ChatTextInput`


The following common components are added:
- `TextArea`
- `CurrencyField`
- `BrandedButton`


## Design link:
- [Figma Link](https://www.figma.com/design/Tc8jXAZgTGMI2iOCMCOjW5/Chatbot-%7C-Hand-off?node-id=0-1&t=veqVQdpwTFxJyGnQ-0)
