### PR TITLE
Add `placeholder`, `sx`, `anchorOrigin` and `transformOrigin` props in CustomSelect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hunar.ai/hunar-design-system",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Hunar's Design System",
   "repository": {
     "type": "git",

--- a/src/components/CustomSelect/CustomSelect.stories.tsx
+++ b/src/components/CustomSelect/CustomSelect.stories.tsx
@@ -8,7 +8,7 @@ import { StorySection } from '@/components/storybook';
 import { HelperText } from '@/components/HelperText';
 import { CustomSelect, CustomSelectProps } from './CustomSelect';
 
-import { FIELD_SIZE } from '@/Enum';
+import { FIELD_SIZE, POPOVER_ORIGIN } from '@/Enum';
 import { OptionsProps } from '@/interfaces';
 
 const onChange = action('change');
@@ -87,6 +87,14 @@ const CustomSelectStates = (props: CustomSelectProps) => {
                 disabled
             />
             <CustomSelectSection
+                sectionTitle="Placeholder"
+                // eslint-disable-next-line max-len
+                sectionDescription='Here, the placeholder is "Choose Option". Try changing the placeholder from controls'
+                {...props}
+                name="placeholder"
+                placeholder="Choose Option"
+            />
+            <CustomSelectSection
                 sectionTitle="Disabled Options"
                 {...props}
                 name="disabledOptions "
@@ -148,6 +156,14 @@ const meta = {
         size: {
             control: 'select',
             options: [FIELD_SIZE.small, FIELD_SIZE.medium]
+        },
+        anchorOrigin: {
+            control: 'select',
+            options: Object.values(POPOVER_ORIGIN)
+        },
+        transformOrigin: {
+            control: 'select',
+            options: Object.values(POPOVER_ORIGIN)
         }
     },
     args: {
@@ -201,10 +217,19 @@ export const Playground: StoryProps = {
     }
 };
 
+const allowedControls = [
+    'multiple',
+    'size',
+    'sx',
+    'primaryColor',
+    'optionsHeaderTitle',
+    'placeholder'
+];
+
 export const SingleSelect: StoryProps = {
     parameters: {
         controls: {
-            include: ['multiple', 'size', 'primaryColor', 'optionsHeaderTitle']
+            include: allowedControls
         }
     },
     argTypes: { multiple: { control: 'select', options: [false] } },
@@ -217,7 +242,7 @@ export const SingleSelect: StoryProps = {
 export const MultiSelect: StoryProps = {
     parameters: {
         controls: {
-            include: ['multiple', 'size', 'primaryColor', 'optionsHeaderTitle']
+            include: allowedControls
         }
     },
     argTypes: { multiple: { control: 'select', options: [true] } },

--- a/src/components/CustomSelect/CustomSelectHeader.tsx
+++ b/src/components/CustomSelect/CustomSelectHeader.tsx
@@ -40,7 +40,7 @@ export const CustomSelectHeader = ({
             <Grid container alignItems="center" px={2} py={1.5}>
                 <Grid item xs>
                     <Typography
-                        variant="caption"
+                        variant="overline"
                         textTransform="uppercase"
                         color={grey[700]}
                     >

--- a/src/components/MobileDatePicker/MobileDatePicker.tsx
+++ b/src/components/MobileDatePicker/MobileDatePicker.tsx
@@ -138,6 +138,7 @@ export const MobileDatePicker = ({
 
     const datePickerSx: SxProps = React.useMemo(() => {
         return {
+            minWidth: 250,
             '.datepicker.default': {
                 position: 'static',
                 bgcolor: 'white',


### PR DESCRIPTION
This PR adds the following new props in `CustomSelect` for integration of the component into Chatbot

- `placeholder`
- `sx`
- `anchorOrigin`
- `transformOrigin`


## Links:
- [Design Link](https://www.figma.com/design/Tc8jXAZgTGMI2iOCMCOjW5/Chatbot-%7C-Hand-off?node-id=0-1&t=1mm4pqGYpcB8MeZl-0)
- [Storybook Link](https://custom-select--666ac08efe69dd9c59a1e4c6.chromatic.com/?path=/docs/components-customselect--docs)