### PR TITLE
Add code preview in each story in storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -10,6 +10,9 @@ const config: StorybookConfig = {
         '@storybook/addon-interactions',
         '@storybook/addon-themes'
     ],
+    docs: {
+        defaultName: 'Documentation'
+    },
     framework: {
         name: '@storybook/react-vite',
         options: {}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 
 import type { Preview } from '@storybook/react';
 import { withThemeFromJSXProvider } from '@storybook/addon-themes';
+import {
+    Title,
+    Subtitle,
+    Description,
+    Primary,
+    Controls
+} from '@storybook/blocks';
 
 import { ThemeProvider, CssBaseline } from '@mui/material';
 import { grey } from '@mui/material/colors';
@@ -26,6 +33,18 @@ const preview: Preview = {
                 color: /(background|color)$/i,
                 date: /Date$/i
             }
+        },
+        docs: {
+            canvas: { sourceState: 'shown' },
+            page: () => (
+                <>
+                    <Title />
+                    <Subtitle />
+                    <Description />
+                    <Primary />
+                    <Controls />
+                </>
+            )
         }
     },
     tags: ['autodocs'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hunar.ai/hunar-design-system",
-  "version": "0.4.0-rc.1",
+  "version": "0.4.1",
   "description": "Hunar's Design System",
   "repository": {
     "type": "git",

--- a/src/components/CustomSelect/CustomSelect.stories.tsx
+++ b/src/components/CustomSelect/CustomSelect.stories.tsx
@@ -192,6 +192,14 @@ type StoryProps = StoryObj<typeof CustomSelect>;
 
 export const Playground: StoryProps = {
     args: { disabledOptions: [] },
+    decorators: Story => (
+        <StorySection
+            title=""
+            description='Change various props in the "Controls" panel to see how they change behavior of the component'
+        >
+            <Story />
+        </StorySection>
+    ),
     render: function Playground(props) {
         const [{ multiple }, updateArg] =
             useArgs<NonNullable<StoryProps['args']>>();
@@ -213,17 +221,11 @@ export const Playground: StoryProps = {
         };
 
         return (
-            <StorySection
-                title=""
-                // eslint-disable-next-line max-len
-                description={`Change various props in the "Controls" panel to see how they change behavior of the component`}
-            >
-                <CustomSelect
-                    {...props}
-                    value={multiple ? multiSelectValue : singleSelectValue}
-                    onChange={onSelectChange}
-                />
-            </StorySection>
+            <CustomSelect
+                {...props}
+                value={multiple ? multiSelectValue : singleSelectValue}
+                onChange={onSelectChange}
+            />
         );
     }
 };

--- a/src/components/DotDivider/DotDivider.stories.tsx
+++ b/src/components/DotDivider/DotDivider.stories.tsx
@@ -26,25 +26,29 @@ export default meta;
 type StoryProps = StoryObj<typeof DotDivider>;
 
 export const Playground: StoryProps = {
+    decorators: Story => (
+        <StorySection
+            title=""
+            description='Change various props in the "Controls" panel to see how they change behavior of the component'
+        >
+            <Story />
+        </StorySection>
+    ),
     render: function Playground(props) {
         return (
-            <StorySection
-                title=""
-                // eslint-disable-next-line max-len
-                description={`Change various props in the "Controls" panel to see how they change behavior of the component`}
+            <Box
+                display="flex"
+                justifyContent="center"
+                alignItems="center"
+                width="100%"
+                columnGap={0.5}
             >
-                <Box
-                    display="flex"
-                    justifyContent="center"
-                    alignItems="center"
-                    width="100%"
-                    columnGap={0.5}
-                >
-                    Apple <DotDivider {...props} />
-                    Mango <DotDivider {...props} />
-                    Orange
-                </Box>
-            </StorySection>
+                {`Apple `}
+                <DotDivider {...props} />
+                {`Mango `}
+                <DotDivider {...props} />
+                {`Orange`}
+            </Box>
         );
     }
 };

--- a/src/components/EditableTextArea/EditableTextArea.stories.tsx
+++ b/src/components/EditableTextArea/EditableTextArea.stories.tsx
@@ -134,13 +134,25 @@ export default meta;
 type StoryProps = StoryObj<typeof EditableTextArea>;
 
 export const Playground: StoryProps = {
-    render: function Playground(props) {
+    decorators: Story => (
+        <StorySection
+            title=""
+            description='Change various props in the "Controls" panel to see how they change behavior of the component'
+        >
+            <Story />
+        </StorySection>
+    ),
+    render: function Playground({ value, ...props }) {
+        const [valueState, setValueState] = React.useState(value);
+
         return (
-            <EditableTextAreaSection
-                sectionTitle=""
-                // eslint-disable-next-line max-len
-                sectionDescription={`Change various props in the "Controls" panel to see how they change behavior of the component`}
+            <EditableTextArea
                 {...props}
+                value={valueState}
+                onSave={modifiedValue => {
+                    onSave(modifiedValue);
+                    setValueState(modifiedValue);
+                }}
             />
         );
     }

--- a/src/components/EditableTextField/EditableTextField.stories.tsx
+++ b/src/components/EditableTextField/EditableTextField.stories.tsx
@@ -148,13 +148,25 @@ export default meta;
 type StoryProps = StoryObj<typeof EditableTextField>;
 
 export const Playground: StoryProps = {
-    render: function Playground(props) {
+    decorators: Story => (
+        <StorySection
+            title=""
+            description='Change various props in the "Controls" panel to see how they change behavior of the component'
+        >
+            <Story />
+        </StorySection>
+    ),
+    render: function Playground({ value, ...props }) {
+        const [valueState, setValueState] = React.useState(value);
+
         return (
-            <EditableTextFieldSection
-                sectionTitle=""
-                // eslint-disable-next-line max-len
-                sectionDescription={`Change various props in the "Controls" panel to see how they change behavior of the component`}
+            <EditableTextField
                 {...props}
+                value={valueState}
+                onSave={modifiedValue => {
+                    onSave(modifiedValue);
+                    setValueState(modifiedValue);
+                }}
             />
         );
     }

--- a/src/components/KebabMenu/KebabMenu.stories.tsx
+++ b/src/components/KebabMenu/KebabMenu.stories.tsx
@@ -71,16 +71,16 @@ export default meta;
 type StoryProps = StoryObj<typeof KebabMenu>;
 
 export const Playground: StoryProps = {
+    decorators: Story => (
+        <StorySection
+            title=""
+            description='Change various props in the "Controls" panel to see how they change behavior of the component'
+        >
+            <Story />
+        </StorySection>
+    ),
     render: function Playground(props) {
-        return (
-            <StorySection
-                title=""
-                // eslint-disable-next-line max-len
-                description={`Change various props in the "Controls" panel to see how they change behavior of the component`}
-            >
-                <KebabMenu {...props} />
-            </StorySection>
-        );
+        return <KebabMenu {...props} />;
     }
 };
 

--- a/src/components/MobileDatePicker/MobileDatePicker.stories.tsx
+++ b/src/components/MobileDatePicker/MobileDatePicker.stories.tsx
@@ -199,13 +199,25 @@ export default meta;
 type StoryProps = StoryObj<typeof MobileDatePicker>;
 
 export const Playground: StoryProps = {
-    render: function Playground(props) {
+    decorators: Story => (
+        <StorySection
+            title=""
+            description='Change various props in the "Controls" panel to see how they change behavior of the component'
+        >
+            <Story />
+        </StorySection>
+    ),
+    render: function Playground({ value, ...props }) {
+        const [selectedValue, setSelectedValue] = React.useState(value);
+
         return (
-            <MobileDatePickerSection
-                sectionTitle=""
-                // eslint-disable-next-line max-len
-                sectionDescription={`Change various props in the "Controls" panel to see how they change behavior of the component`}
+            <MobileDatePicker
                 {...props}
+                value={selectedValue}
+                onChange={modifiedValue => {
+                    onChange(modifiedValue);
+                    setSelectedValue(modifiedValue);
+                }}
             />
         );
     }


### PR DESCRIPTION
This PR adds code previews for each stories in storybook

## Features:

- change name for docs page from "Docs" to "Documentation" page in all stories
- update the content of docs page
- add code preview of component in "Documentation" page

## Links:
- [Storybook](https://code-preview--666ac08efe69dd9c59a1e4c6.chromatic.com/?path=/docs/components-copytoclipboard--documentation)