### PR TITLE
Add edit start/end callbacks in input fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hunar.ai/hunar-design-system",
-  "version": "0.5.3-rc.1",
+  "version": "0.5.3",
   "description": "Hunar's Design System",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hunar.ai/hunar-design-system",
-  "version": "0.5.2",
+  "version": "0.5.3-rc.1",
   "description": "Hunar's Design System",
   "repository": {
     "type": "git",

--- a/src/components/CustomSelect/CustomSelect.stories.tsx
+++ b/src/components/CustomSelect/CustomSelect.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { useArgs } from '@storybook/preview-api';
 
 import { StorySection } from '@/components/storybook';
 import { HelperText } from '@/components/HelperText';
@@ -12,6 +11,8 @@ import { FIELD_SIZE, POPOVER_ORIGIN } from '@/Enum';
 import { OptionsProps } from '@/interfaces';
 
 const onChange = action('change');
+const onMenuOpen = action('menuOpen');
+const onMenuClose = action('menuClose');
 
 const options: OptionsProps = [
     {
@@ -199,7 +200,9 @@ const meta = {
         name: 'movies',
         options,
         value: null,
-        onChange
+        onChange,
+        onMenuOpen,
+        onMenuClose
     }
 } satisfies Meta<typeof CustomSelect>;
 
@@ -218,9 +221,6 @@ export const Playground: StoryProps = {
         </StorySection>
     ),
     render: function Playground(props) {
-        const [{ multiple }, updateArg] =
-            useArgs<NonNullable<StoryProps['args']>>();
-
         const [singleSelectValue, setSingleSelectValue] =
             React.useState<CustomSelectProps['value']>(null);
         const [multiSelectValue, setMultiSelectValue] = React.useState<
@@ -229,7 +229,6 @@ export const Playground: StoryProps = {
 
         const onSelectChange: CustomSelectProps['onChange'] = updatedValue => {
             onChange(updatedValue);
-            updateArg({ value: updatedValue });
             if (Array.isArray(updatedValue)) {
                 setMultiSelectValue(updatedValue);
             } else {
@@ -240,7 +239,7 @@ export const Playground: StoryProps = {
         return (
             <CustomSelect
                 {...props}
-                value={multiple ? multiSelectValue : singleSelectValue}
+                value={props.multiple ? multiSelectValue : singleSelectValue}
                 onChange={onSelectChange}
             />
         );

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -49,6 +49,8 @@ export interface CustomSelectProps {
     transformOrigin?: POPOVER_ORIGIN;
     menuMarginThreshold?: number;
     onChange: (_: OptionProps | OptionsProps | null) => void;
+    onMenuOpen?: () => void;
+    onMenuClose?: () => void;
 }
 
 export const CustomSelect = ({
@@ -72,7 +74,9 @@ export const CustomSelect = ({
     anchorOrigin = POPOVER_ORIGIN.BOTTOM_CENTER,
     transformOrigin = POPOVER_ORIGIN.TOP_CENTER,
     menuMarginThreshold = undefined,
-    onChange
+    onChange,
+    onMenuOpen = () => undefined,
+    onMenuClose = () => undefined
 }: CustomSelectProps) => {
     const isMobile = useIsMobile();
     const theme = useTheme();
@@ -115,11 +119,17 @@ export const CustomSelect = ({
         return modifiedOptions;
     }, [options, search]);
 
+    const onOpenClick = React.useCallback(() => {
+        onMenuOpen();
+        setIsOpen(true);
+    }, [onMenuOpen]);
+
     const onCloseClick = React.useCallback(() => {
+        onMenuClose();
         setIsOpen(false);
         setSelectedValue(initialSelectedValue);
         setSearch('');
-    }, [initialSelectedValue]);
+    }, [initialSelectedValue, onMenuClose]);
 
     const menuProps: Partial<MenuProps> = React.useMemo(
         () => ({
@@ -262,10 +272,11 @@ export const CustomSelect = ({
             );
         }
 
+        onMenuClose();
         onChange(modifiedSelectedOptions);
         setIsOpen(false);
         setSearch('');
-    }, [onChange, selectedValue, valueToOptionMap]);
+    }, [onChange, onMenuClose, selectedValue, valueToOptionMap]);
 
     const valueWithPlaceholder = React.useMemo(() => {
         if (Array.isArray(initialSelectedValue)) {
@@ -298,7 +309,7 @@ export const CustomSelect = ({
                 value={valueWithPlaceholder}
                 renderValue={getSelectValuePreview}
                 MenuProps={menuProps}
-                onOpen={() => setIsOpen(true)}
+                onOpen={onOpenClick}
             >
                 <CustomSelectHeader
                     title={optionsHeaderTitle || label}

--- a/src/components/EditableTextArea/EditableTextArea.stories.tsx
+++ b/src/components/EditableTextArea/EditableTextArea.stories.tsx
@@ -9,6 +9,8 @@ import { EditableTextArea, EditableTextAreaProps } from './EditableTextArea';
 import { BUTTON_SIZE, FIELD_SIZE } from '@/Enum';
 
 const onSave = action('save');
+const onEditStart = action('editStart');
+const onEditEnd = action('editEnd');
 
 const ControlledEditableTextArea = ({
     value,
@@ -126,7 +128,7 @@ const meta = {
             options: [BUTTON_SIZE.small, BUTTON_SIZE.medium, BUTTON_SIZE.large]
         }
     },
-    args: { value: '', onSave }
+    args: { value: '', onSave, onEditStart, onEditEnd }
 } satisfies Meta<typeof EditableTextArea>;
 
 export default meta;

--- a/src/components/EditableTextArea/EditableTextArea.tsx
+++ b/src/components/EditableTextArea/EditableTextArea.tsx
@@ -66,33 +66,30 @@ export const EditableTextArea = ({
         setEditedValue(e.target.value);
     };
 
-    const onFocus = () => {
+    const handleEditStart = () => {
         onEditStart();
         setIsEditing(true);
+    };
+
+    const handleEditEnd = () => {
+        onEditEnd();
+        setIsEditing(false);
     };
 
     const onBlur = () => {
         if (!value && !editedValue) {
-            onEditEnd();
-            setIsEditing(false);
+            handleEditEnd();
         }
     };
 
-    const onEditClick = () => {
-        onEditStart();
-        setIsEditing(true);
-    };
-
     const handleCancelClick = () => {
-        onEditEnd();
+        handleEditEnd();
         setEditedValue(value);
-        setIsEditing(false);
     };
 
     const handleSaveClick = () => {
-        onEditEnd();
+        handleEditEnd();
         onSave(editedValue);
-        setIsEditing(false);
     };
 
     return (
@@ -110,7 +107,7 @@ export const EditableTextArea = ({
                     error={hasErrors}
                     sx={inputFieldSx}
                     onChange={onFieldChange}
-                    onFocus={onFocus}
+                    onFocus={handleEditStart}
                     onBlur={onBlur}
                     helperText={
                         <HelperText
@@ -126,7 +123,7 @@ export const EditableTextArea = ({
                     fieldSize={fieldSize}
                     isDisabled={disabled}
                     sx={previewSx}
-                    onEditClick={onEditClick}
+                    onEditClick={handleEditStart}
                 />
             )}
             {isEditing && (

--- a/src/components/EditableTextArea/EditableTextArea.tsx
+++ b/src/components/EditableTextArea/EditableTextArea.tsx
@@ -109,6 +109,7 @@ export const EditableTextArea = ({
                 <EditableTextFieldPreview
                     previewText={value}
                     fieldSize={fieldSize}
+                    isDisabled={disabled}
                     sx={previewSx}
                     onEditClick={() => setIsEditing(true)}
                 />
@@ -117,8 +118,8 @@ export const EditableTextArea = ({
                 <EditableTextFieldCtaList
                     buttonSize={buttonSize}
                     primaryColor={selectedPrimaryColor}
-                    isCancelDisabled={!editedValue || hasErrors}
-                    isSaveDisabled={!editedValue || hasErrors}
+                    isCancelDisabled={!editedValue || hasErrors || disabled}
+                    isSaveDisabled={!editedValue || hasErrors || disabled}
                     onCancelClick={handleCancelClick}
                     onSaveClick={handleSaveClick}
                 />

--- a/src/components/EditableTextArea/EditableTextArea.tsx
+++ b/src/components/EditableTextArea/EditableTextArea.tsx
@@ -24,6 +24,8 @@ export interface EditableTextAreaProps {
     inputFieldSx?: SxProps;
     previewSx?: SxProps;
     onSave: (_: string) => void;
+    onEditStart?: () => void;
+    onEditEnd?: () => void;
     handleIsValidCheck?: (_: string) => boolean;
 }
 
@@ -42,6 +44,8 @@ export const EditableTextArea = ({
     inputFieldSx = {},
     previewSx = {},
     onSave,
+    onEditStart = () => undefined,
+    onEditEnd = () => undefined,
     handleIsValidCheck = undefined
 }: EditableTextAreaProps) => {
     const theme = useTheme();
@@ -62,20 +66,31 @@ export const EditableTextArea = ({
         setEditedValue(e.target.value);
     };
 
-    const onFocus = () => setIsEditing(true);
+    const onFocus = () => {
+        onEditStart();
+        setIsEditing(true);
+    };
 
     const onBlur = () => {
         if (!value && !editedValue) {
+            onEditEnd();
             setIsEditing(false);
         }
     };
 
+    const onEditClick = () => {
+        onEditStart();
+        setIsEditing(true);
+    };
+
     const handleCancelClick = () => {
+        onEditEnd();
         setEditedValue(value);
         setIsEditing(false);
     };
 
     const handleSaveClick = () => {
+        onEditEnd();
         onSave(editedValue);
         setIsEditing(false);
     };
@@ -111,7 +126,7 @@ export const EditableTextArea = ({
                     fieldSize={fieldSize}
                     isDisabled={disabled}
                     sx={previewSx}
-                    onEditClick={() => setIsEditing(true)}
+                    onEditClick={onEditClick}
                 />
             )}
             {isEditing && (

--- a/src/components/EditableTextField/EditableTextField.stories.tsx
+++ b/src/components/EditableTextField/EditableTextField.stories.tsx
@@ -9,6 +9,8 @@ import { EditableTextField, EditableTextFieldProps } from './EditableTextField';
 import { BUTTON_SIZE, TEXT_INPUT_VARIANT, FIELD_SIZE } from '@/Enum';
 
 const onSave = action('save');
+const onEditStart = action('editStart');
+const onEditEnd = action('editEnd');
 
 const ControlledEditableTextField = ({
     value,
@@ -140,7 +142,7 @@ const meta = {
             control: 'text'
         }
     },
-    args: { value: '', onSave }
+    args: { value: '', onSave, onEditStart, onEditEnd }
 } satisfies Meta<typeof EditableTextField>;
 
 export default meta;

--- a/src/components/EditableTextField/EditableTextField.tsx
+++ b/src/components/EditableTextField/EditableTextField.tsx
@@ -78,33 +78,30 @@ export const EditableTextField = ({
         setEditedValue(e.target.value);
     };
 
-    const onFocus = () => {
+    const handleEditStart = () => {
         onEditStart();
         setIsEditing(true);
+    };
+
+    const handleEditEnd = () => {
+        onEditEnd();
+        setIsEditing(false);
     };
 
     const onBlur = () => {
         if (!value && !editedValue) {
-            onEditEnd();
-            setIsEditing(false);
+            handleEditEnd();
         }
     };
 
-    const onEditClick = () => {
-        onEditStart();
-        setIsEditing(true);
-    };
-
     const handleCancelClick = () => {
-        onEditEnd();
+        handleEditEnd();
         setEditedValue(value);
-        setIsEditing(false);
     };
 
     const handleSaveClick = () => {
-        onEditEnd();
+        handleEditEnd();
         onSave(editedValue);
-        setIsEditing(false);
     };
 
     return (
@@ -127,7 +124,7 @@ export const EditableTextField = ({
                     textFieldType={textFieldType}
                     inputFieldSx={inputFieldSx}
                     onFieldChange={onFieldChange}
-                    onFocus={onFocus}
+                    onFocus={handleEditStart}
                     onBlur={onBlur}
                 />
             ) : (
@@ -136,7 +133,7 @@ export const EditableTextField = ({
                     fieldSize={fieldSize}
                     sx={previewSx}
                     isDisabled={disabled}
-                    onEditClick={onEditClick}
+                    onEditClick={handleEditStart}
                 />
             )}
             {isEditing && (

--- a/src/components/EditableTextField/EditableTextField.tsx
+++ b/src/components/EditableTextField/EditableTextField.tsx
@@ -27,6 +27,8 @@ export interface EditableTextFieldProps {
     inputFieldSx?: SxProps;
     previewSx?: SxProps;
     onSave: (_: string) => void;
+    onEditStart?: () => void;
+    onEditEnd?: () => void;
     handleIsValidCheck?: (_: string) => boolean;
 }
 
@@ -48,6 +50,8 @@ export const EditableTextField = ({
     inputFieldSx = {},
     previewSx = {},
     onSave,
+    onEditStart = () => undefined,
+    onEditEnd = () => undefined,
     handleIsValidCheck = undefined
 }: EditableTextFieldProps) => {
     const theme = useTheme();
@@ -74,20 +78,31 @@ export const EditableTextField = ({
         setEditedValue(e.target.value);
     };
 
-    const onFocus = () => setIsEditing(true);
+    const onFocus = () => {
+        onEditStart();
+        setIsEditing(true);
+    };
 
     const onBlur = () => {
         if (!value && !editedValue) {
+            onEditEnd();
             setIsEditing(false);
         }
     };
 
+    const onEditClick = () => {
+        onEditStart();
+        setIsEditing(true);
+    };
+
     const handleCancelClick = () => {
+        onEditEnd();
         setEditedValue(value);
         setIsEditing(false);
     };
 
     const handleSaveClick = () => {
+        onEditEnd();
         onSave(editedValue);
         setIsEditing(false);
     };
@@ -121,7 +136,7 @@ export const EditableTextField = ({
                     fieldSize={fieldSize}
                     sx={previewSx}
                     isDisabled={disabled}
-                    onEditClick={() => setIsEditing(true)}
+                    onEditClick={onEditClick}
                 />
             )}
             {isEditing && (

--- a/src/components/EditableTextField/EditableTextField.tsx
+++ b/src/components/EditableTextField/EditableTextField.tsx
@@ -120,6 +120,7 @@ export const EditableTextField = ({
                     previewText={formattedPreviewText}
                     fieldSize={fieldSize}
                     sx={previewSx}
+                    isDisabled={disabled}
                     onEditClick={() => setIsEditing(true)}
                 />
             )}
@@ -127,8 +128,8 @@ export const EditableTextField = ({
                 <EditableTextFieldCtaList
                     buttonSize={buttonSize}
                     primaryColor={selectedPrimaryColor}
-                    isCancelDisabled={!editedValue || hasErrors}
-                    isSaveDisabled={!editedValue || hasErrors}
+                    isCancelDisabled={!editedValue || hasErrors || disabled}
+                    isSaveDisabled={!editedValue || hasErrors || disabled}
                     onCancelClick={handleCancelClick}
                     onSaveClick={handleSaveClick}
                 />

--- a/src/components/EditableTextField/EditableTextFieldPreview.tsx
+++ b/src/components/EditableTextField/EditableTextFieldPreview.tsx
@@ -1,4 +1,4 @@
-import { Grid, IconButton, SxProps, Typography } from '@mui/material';
+import { Grid, IconButton, SxProps, Typography, useTheme } from '@mui/material';
 import { EditOutlined as EditOutlinedIcon } from '@mui/icons-material';
 import { grey } from '@mui/material/colors';
 
@@ -7,6 +7,7 @@ import { FIELD_SIZE } from '@/Enum';
 interface EditableTextFieldPreviewProps {
     previewText: string;
     fieldSize: FIELD_SIZE;
+    isDisabled: boolean;
     sx?: SxProps;
     onEditClick: VoidFunction;
 }
@@ -14,9 +15,11 @@ interface EditableTextFieldPreviewProps {
 export const EditableTextFieldPreview = ({
     previewText,
     fieldSize,
+    isDisabled,
     sx = {},
     onEditClick
 }: EditableTextFieldPreviewProps) => {
+    const theme = useTheme();
     return (
         <Grid
             item
@@ -28,6 +31,7 @@ export const EditableTextFieldPreview = ({
             px={1.75}
             py={fieldSize === FIELD_SIZE.small ? 0 : 1}
             maxWidth="100%"
+            color={isDisabled ? theme.palette.action.disabled : undefined}
         >
             <Typography
                 whiteSpace="nowrap"
@@ -36,7 +40,11 @@ export const EditableTextFieldPreview = ({
             >
                 {previewText}
             </Typography>
-            <IconButton sx={{ p: 1.25, mr: -1.25 }} onClick={onEditClick}>
+            <IconButton
+                sx={{ p: 1.25, mr: -1.25 }}
+                onClick={onEditClick}
+                disabled={isDisabled}
+            >
                 <EditOutlinedIcon fontSize="small" />
             </IconButton>
         </Grid>

--- a/src/components/MobileDatePicker/MobileDatePicker.stories.tsx
+++ b/src/components/MobileDatePicker/MobileDatePicker.stories.tsx
@@ -14,6 +14,8 @@ import {
 import { FIELD_SIZE, POPOVER_ORIGIN } from '@/Enum';
 
 const onChange = action('change');
+const onMenuOpen = action('menuOpen');
+const onMenuClose = action('menuClose');
 
 const customDateConfig: DatePickerConfigProps[] = [
     { type: 'year', format: 'YYYY', caption: 'Year', step: 1 },
@@ -190,7 +192,9 @@ const meta = {
         label: 'Date',
         name: 'date',
         value: null,
-        onChange
+        onChange,
+        onMenuOpen,
+        onMenuClose
     }
 } satisfies Meta<typeof MobileDatePicker>;
 

--- a/src/components/MobileDatePicker/MobileDatePicker.tsx
+++ b/src/components/MobileDatePicker/MobileDatePicker.tsx
@@ -63,6 +63,8 @@ export interface MobileDatePickerProps {
     transformOrigin?: POPOVER_ORIGIN;
     menuMarginThreshold?: number;
     onChange: (_: Date) => void;
+    onMenuOpen?: () => void;
+    onMenuClose?: () => void;
     getValuePreview?: (_: Date | string) => string;
 }
 
@@ -88,6 +90,8 @@ export const MobileDatePicker = ({
     transformOrigin = POPOVER_ORIGIN.TOP_CENTER,
     menuMarginThreshold = undefined,
     onChange,
+    onMenuOpen = () => undefined,
+    onMenuClose = () => undefined,
     getValuePreview = undefined
 }: MobileDatePickerProps) => {
     const isMobile = useIsMobile();
@@ -102,10 +106,16 @@ export const MobileDatePicker = ({
         setSelectedValue(value || new Date());
     }, [value]);
 
+    const onOpenClick = React.useCallback(() => {
+        onMenuOpen();
+        setIsOpen(true);
+    }, [onMenuOpen]);
+
     const onCloseClick = React.useCallback(() => {
+        onMenuClose();
         setIsOpen(false);
         setSelectedValue(value || new Date());
-    }, [value]);
+    }, [value, onMenuClose]);
 
     const menuProps: Partial<MenuProps> = React.useMemo(
         () => ({
@@ -203,9 +213,10 @@ export const MobileDatePicker = ({
     );
 
     const onConfirmClick = React.useCallback(() => {
+        onMenuClose();
         onChange(selectedValue);
         setIsOpen(false);
-    }, [onChange, selectedValue]);
+    }, [onChange, onMenuClose, selectedValue]);
 
     return (
         <FormControl
@@ -228,7 +239,7 @@ export const MobileDatePicker = ({
                 sx={sx}
                 renderValue={getValuePreview ?? getDefaultValuePreview}
                 MenuProps={menuProps}
-                onOpen={() => setIsOpen(true)}
+                onOpen={onOpenClick}
             >
                 <MobileDatePickerHeader
                     title={pickerHeaderTitle || label}


### PR DESCRIPTION
This PR introduces the following changes:

## Features:

1. add edit start/end callback in the following fields
   1. `EditableTextField`
   2. `EditableTextArea`
   3. `CustomSelect`
   4. `MobileDatePicker`
1. fix: :bug: when `disabled` prop is passed, text preview & edit button should also get disabled
   1. `EditableTextField`
   2. `EditableTextArea`
   
## Link:
1. [Storybook Link](https://field-edit-callback--666ac08efe69dd9c59a1e4c6.chromatic.com/?path=/docs/components-editabletextarea--documentation)
