### PR TITLE
Add `Select` and `AdaptiveSelect` components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hunar.ai/hunar-design-system",
-  "version": "0.5.3",
+  "version": "0.5.4-rc.1",
   "description": "Hunar's Design System",
   "repository": {
     "type": "git",

--- a/src/Enum.ts
+++ b/src/Enum.ts
@@ -51,3 +51,13 @@ export enum TEXT_INPUT_VARIANT {
     TEXT_FIELD = 'TEXT_FIELD',
     CURRENCY = 'CURRENCY'
 }
+
+export enum SELECT_OPTION_TYPE {
+    TEXTFIELD = 'TEXTFIELD',
+    CHECKBOX = 'CHECKBOX'
+}
+
+export enum COMMON_VALUE {
+    NA = 'NA',
+    NEW = 'NEW'
+}

--- a/src/components/AdaptiveSelect/AdaptiveSelect.stories.tsx
+++ b/src/components/AdaptiveSelect/AdaptiveSelect.stories.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import { StorySection } from '@/components/storybook';
+import { HelperText } from '@/components/HelperText';
+import { AdaptiveSelect, type AdaptiveSelectProps } from './AdaptiveSelect';
+import { options } from '@/components/Select/Select.stories';
+
+import { FIELD_SIZE } from '@/Enum';
+
+const onSelectChange = action('selectChange');
+const onTextInputChange = action('textChange');
+
+const ControlledAdaptiveSelect = ({
+    value,
+    onSelectChange,
+    onTextInputChange,
+    ...props
+}: AdaptiveSelectProps) => {
+    const [adaptiveSelectValue, setAdaptiveSelectValue] =
+        React.useState<AdaptiveSelectProps['value']>(value);
+
+    const onAdaptiveSelectChange: AdaptiveSelectProps['onSelectChange'] = (
+        e,
+        updatedValue,
+        reason
+    ) => {
+        onSelectChange(e, updatedValue, reason);
+        setAdaptiveSelectValue(updatedValue?.value ?? '');
+    };
+
+    const onAdaptiveSelectTextChange: AdaptiveSelectProps['onTextInputChange'] =
+        e => {
+            onTextInputChange(e);
+            setAdaptiveSelectValue(e.target.value);
+        };
+
+    return (
+        <AdaptiveSelect
+            {...props}
+            value={adaptiveSelectValue}
+            onSelectChange={onAdaptiveSelectChange}
+            onTextInputChange={onAdaptiveSelectTextChange}
+        />
+    );
+};
+
+interface AdaptiveSelectSectionProps extends AdaptiveSelectProps {
+    sectionTitle: string;
+    sectionDescription?: string;
+}
+
+const AdaptiveSelectSection = ({
+    sectionTitle,
+    sectionDescription,
+    ...props
+}: AdaptiveSelectSectionProps) => {
+    return (
+        <StorySection title={sectionTitle} description={sectionDescription}>
+            <ControlledAdaptiveSelect {...props} />
+        </StorySection>
+    );
+};
+
+const AdaptiveSelectStates = (props: AdaptiveSelectProps) => {
+    return (
+        <>
+            <AdaptiveSelectSection
+                sectionTitle="Default"
+                {...props}
+                name="default"
+            />
+            <AdaptiveSelectSection
+                sectionTitle="Disabled"
+                {...props}
+                name="disabled"
+                isDisabled
+            />
+            <AdaptiveSelectSection
+                sectionTitle="Placeholder"
+                selectPlaceHolder="Choose Option"
+                textInputPlaceHolder="Enter Value"
+                {...props}
+                name="placeholder"
+            />
+            <AdaptiveSelectSection
+                sectionTitle="Required"
+                {...props}
+                name="required"
+                isRequired
+            />
+            <AdaptiveSelectSection
+                sectionTitle="Helper Text"
+                {...props}
+                name="helper-text"
+                helperText={<HelperText msg="I have helper text" />}
+            />
+            <AdaptiveSelectSection
+                sectionTitle="Error"
+                {...props}
+                name="error"
+                hasError
+                helperText={<HelperText hasError errorMsg="I have error" />}
+            />
+        </>
+    );
+};
+
+const meta = {
+    title: 'Components/AdaptiveSelect',
+    component: AdaptiveSelect,
+    parameters: { controls: { expanded: true } },
+    argTypes: {
+        value: {
+            table: {
+                type: { summary: `OptionProps | OptionsProps | null` }
+            }
+        },
+        size: {
+            control: 'select',
+            options: [FIELD_SIZE.small, FIELD_SIZE.medium]
+        }
+    },
+    args: {
+        label: 'Movies',
+        name: 'movies',
+        options,
+        value: '',
+        onSelectChange,
+        onTextInputChange
+    }
+} satisfies Meta<typeof AdaptiveSelect>;
+
+export default meta;
+
+type StoryProps = StoryObj<typeof AdaptiveSelect>;
+
+export const Playground: StoryProps = {
+    decorators: Story => (
+        <StorySection
+            title=""
+            description='Change various props in the "Controls" panel to see how they change behavior of the component'
+        >
+            <Story />
+        </StorySection>
+    ),
+    render: function Playground(props) {
+        const [adaptiveSelectValue, setAdaptiveSelectValue] =
+            React.useState<AdaptiveSelectProps['value']>('');
+
+        const onAdaptiveSelectChange: AdaptiveSelectProps['onSelectChange'] = (
+            e,
+            updatedValue
+        ) => {
+            onSelectChange(e, updatedValue);
+            setAdaptiveSelectValue(updatedValue?.value ?? '');
+        };
+
+        const onAdaptiveSelectTextChange: AdaptiveSelectProps['onTextInputChange'] =
+            e => {
+                onTextInputChange(e);
+                setAdaptiveSelectValue(e.target.value);
+            };
+
+        return (
+            <AdaptiveSelect
+                {...props}
+                value={adaptiveSelectValue}
+                onSelectChange={onAdaptiveSelectChange}
+                onTextInputChange={onAdaptiveSelectTextChange}
+            />
+        );
+    }
+};
+
+const allowedControls = ['label', 'name', 'id', 'size', 'sx'];
+
+export const SelectInput: StoryProps = {
+    parameters: {
+        controls: {
+            include: allowedControls
+        }
+    },
+    render: props => <AdaptiveSelectStates {...props} />
+};
+
+export const TextInput: StoryProps = {
+    parameters: {
+        controls: {
+            include: allowedControls
+        }
+    },
+    args: { options: [] },
+    render: props => <AdaptiveSelectStates {...props} />
+};

--- a/src/components/AdaptiveSelect/AdaptiveSelect.tsx
+++ b/src/components/AdaptiveSelect/AdaptiveSelect.tsx
@@ -21,6 +21,7 @@ export interface AdaptiveSelectProps {
     textInputPlaceHolder?: string;
     isRequired?: boolean;
     isDisabled?: boolean;
+    isClearDisabled?: boolean;
     size?: FIELD_SIZE;
     limitTags?: number;
     sx?: SxProps;
@@ -46,6 +47,7 @@ export const AdaptiveSelect = ({
     textInputPlaceHolder = '',
     isRequired = false,
     isDisabled = false,
+    isClearDisabled = false,
     size = FIELD_SIZE.medium,
     limitTags = undefined,
     sx = {},
@@ -80,6 +82,7 @@ export const AdaptiveSelect = ({
                     size={size}
                     limitTags={limitTags}
                     isDisabled={isDisabled}
+                    isClearDisabled={isClearDisabled}
                     options={options}
                     value={getSelectedOption({
                         options,

--- a/src/components/AdaptiveSelect/AdaptiveSelect.tsx
+++ b/src/components/AdaptiveSelect/AdaptiveSelect.tsx
@@ -1,0 +1,114 @@
+import {
+    type AutocompleteChangeReason,
+    type SxProps,
+    TextField
+} from '@mui/material';
+
+import { Select } from '@/components/Select';
+
+import { useFormUtils } from '@/hooks/useFormUtils';
+
+import { FIELD_SIZE } from '@/Enum';
+import type { OptionProps, OptionsProps } from '@/interfaces';
+
+export interface AdaptiveSelectProps {
+    label: string;
+    name: string;
+    id: string;
+    options: OptionsProps;
+    value: string;
+    selectPlaceHolder?: string;
+    textInputPlaceHolder?: string;
+    isRequired?: boolean;
+    isDisabled?: boolean;
+    size?: FIELD_SIZE;
+    limitTags?: number;
+    sx?: SxProps;
+    helperText?: React.ReactNode;
+    hasError?: boolean;
+    onSelectChange: (
+        _: React.SyntheticEvent,
+        __: OptionProps | null,
+        reason: AutocompleteChangeReason
+    ) => void;
+    onTextInputChange: (_: React.ChangeEvent<HTMLInputElement>) => void;
+    onSelectOpen?: (_: React.SyntheticEvent) => void;
+    onTextInputClick?: (_: React.MouseEvent<HTMLDivElement>) => void;
+}
+
+export const AdaptiveSelect = ({
+    label,
+    name,
+    id,
+    options,
+    value,
+    selectPlaceHolder = '',
+    textInputPlaceHolder = '',
+    isRequired = false,
+    isDisabled = false,
+    size = FIELD_SIZE.medium,
+    limitTags = undefined,
+    sx = {},
+    helperText = undefined,
+    hasError = false,
+    onSelectChange,
+    onTextInputChange,
+    onSelectOpen,
+    onTextInputClick
+}: AdaptiveSelectProps) => {
+    const { getSelectedOption } = useFormUtils();
+
+    const handleSelectChange = (
+        e: React.SyntheticEvent,
+        selectedOption: OptionsProps | OptionProps | null,
+        reason: AutocompleteChangeReason
+    ) => {
+        if (Array.isArray(selectedOption)) return;
+
+        onSelectChange(e, selectedOption, reason);
+    };
+
+    return (
+        <>
+            {options.length > 0 ? (
+                <Select
+                    isRequired={isRequired}
+                    label={label}
+                    name={name}
+                    id={id}
+                    placeholder={selectPlaceHolder}
+                    size={size}
+                    limitTags={limitTags}
+                    isDisabled={isDisabled}
+                    options={options}
+                    value={getSelectedOption({
+                        options,
+                        fieldValue: value
+                    })}
+                    sx={sx}
+                    helperText={helperText}
+                    hasError={hasError}
+                    onChange={handleSelectChange}
+                    onOpen={onSelectOpen}
+                />
+            ) : (
+                <TextField
+                    fullWidth
+                    name={name}
+                    id={id}
+                    label={label}
+                    placeholder={textInputPlaceHolder}
+                    size={size}
+                    disabled={isDisabled}
+                    required={isRequired}
+                    value={value}
+                    sx={sx}
+                    helperText={helperText}
+                    error={hasError}
+                    onChange={onTextInputChange}
+                    onClick={onTextInputClick}
+                />
+            )}
+        </>
+    );
+};

--- a/src/components/AdaptiveSelect/index.ts
+++ b/src/components/AdaptiveSelect/index.ts
@@ -1,0 +1,1 @@
+export { AdaptiveSelect, type AdaptiveSelectProps } from './AdaptiveSelect';

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import { StorySection } from '@/components/storybook';
+import { HelperText } from '@/components/HelperText';
+import { Select, type SelectProps } from './Select';
+
+import { COMMON_VALUE, FIELD_SIZE } from '@/Enum';
+import { OptionsProps } from '@/interfaces';
+
+const onChange = action('change');
+const onNewClick = action('newClick');
+
+export const options: OptionsProps = [
+    {
+        label: 'Option with label helper text',
+        value: 'LABEL_HELPER_TEXT',
+        labelHelperText: 'This is helper text for label'
+    },
+    {
+        label: 'VeryLongOptionWithoutAnySpaceVeryLongOptionWithoutAnySpace',
+        value: 'VERY_LONG_OPTION_WITHOUT_ANY_SPACE'
+    },
+    {
+        label: 'The Godfather',
+        value: 'THE_GODFATHER'
+    },
+    {
+        label: 'The Godfather: Part II',
+        value: 'THE_GODFATHER_PART_II'
+    },
+    {
+        label: 'The Dark Knight',
+        value: 'THE_DARK_KNIGHT'
+    },
+    { label: '12 Angry Men', value: '12_ANGRY_MEN' },
+    { label: 'Pulp Fiction', value: 'PULP_FICTION' },
+    { label: 'Fight Club', value: 'FIGHT_CLUB' },
+    { label: 'Forrest Gump', value: 'FORREST_GUMP' },
+    { label: 'Inception', value: 'INCEPTION' },
+    { label: 'The Matrix', value: 'THE_MATRIX' }
+];
+
+const disabledOptions: OptionsProps = [options[3], options[4], options[6]];
+
+const ControlledSelect = ({ value, onChange, ...props }: SelectProps) => {
+    const [selectedValue, setSelectedValue] =
+        React.useState<SelectProps['value']>(value);
+
+    const onSelectChange: SelectProps['onChange'] = (
+        e,
+        modifiedValue,
+        reason
+    ) => {
+        setSelectedValue(modifiedValue);
+        onChange(e, modifiedValue, reason);
+    };
+
+    return (
+        <Select {...props} value={selectedValue} onChange={onSelectChange} />
+    );
+};
+
+interface SelectSectionProps extends SelectProps {
+    sectionTitle: string;
+    sectionDescription?: string;
+}
+
+const SelectSection = ({
+    sectionTitle,
+    sectionDescription,
+    ...props
+}: SelectSectionProps) => {
+    return (
+        <StorySection title={sectionTitle} description={sectionDescription}>
+            <ControlledSelect {...props} />
+        </StorySection>
+    );
+};
+
+const SelectStates = (props: SelectProps) => {
+    return (
+        <>
+            <SelectSection sectionTitle="Default" {...props} name="default" />
+            <SelectSection
+                sectionTitle="Disabled"
+                {...props}
+                name="disabled"
+                isDisabled
+            />
+            <SelectSection
+                sectionTitle="Placeholder"
+                // eslint-disable-next-line max-len
+                sectionDescription='Here, the placeholder is "Choose Option". Try changing the placeholder from controls'
+                placeholder="Choose Option"
+                {...props}
+                name="placeholder"
+            />
+            <SelectSection
+                sectionTitle="With 'Add New' Option"
+                {...props}
+                name="disabledOptions "
+                options={[
+                    { value: COMMON_VALUE.NEW, label: 'Add New Option' },
+                    ...options
+                ]}
+            />
+            <SelectSection
+                sectionTitle="Disabled Options"
+                {...props}
+                name="disabledOptions "
+                disabledOptions={disabledOptions}
+            />
+            <SelectSection
+                sectionTitle="No Options"
+                {...props}
+                name="noOptions"
+                options={[]}
+            />
+            <SelectSection
+                sectionTitle="Required"
+                {...props}
+                name="required"
+                isRequired
+            />
+            <SelectSection
+                sectionTitle="Helper Text"
+                {...props}
+                name="helper-text"
+                helperText={<HelperText msg="I have helper text" />}
+            />
+            <SelectSection
+                sectionTitle="Error"
+                {...props}
+                name="error"
+                hasError
+                helperText={<HelperText hasError errorMsg="I have error" />}
+            />
+        </>
+    );
+};
+
+const meta = {
+    title: 'Components/Select',
+    component: Select,
+    parameters: { controls: { expanded: true } },
+    excludeStories: ['options'],
+    argTypes: {
+        value: {
+            table: {
+                type: { summary: `OptionProps | OptionsProps | null` }
+            }
+        },
+        size: {
+            control: 'select',
+            options: [FIELD_SIZE.small, FIELD_SIZE.medium]
+        }
+    },
+    args: {
+        label: 'Movies',
+        name: 'movies',
+        options,
+        value: null,
+        onChange,
+        onNewClick
+    }
+} satisfies Meta<typeof Select>;
+
+export default meta;
+
+type StoryProps = StoryObj<typeof Select>;
+
+export const Playground: StoryProps = {
+    args: { disabledOptions: [] },
+    decorators: Story => (
+        <StorySection
+            title=""
+            description='Change various props in the "Controls" panel to see how they change behavior of the component'
+        >
+            <Story />
+        </StorySection>
+    ),
+    render: function Playground(props) {
+        const [singleSelectValue, setSingleSelectValue] =
+            React.useState<SelectProps['value']>(null);
+        const [multiSelectValue, setMultiSelectValue] = React.useState<
+            SelectProps['value']
+        >([]);
+
+        const onSelectChange: SelectProps['onChange'] = (e, updatedValue) => {
+            onChange(e, updatedValue);
+            if (Array.isArray(updatedValue)) {
+                setMultiSelectValue(updatedValue);
+            } else {
+                setSingleSelectValue(updatedValue);
+            }
+        };
+
+        return (
+            <Select
+                {...props}
+                value={props.isMultiple ? multiSelectValue : singleSelectValue}
+                onChange={onSelectChange}
+            />
+        );
+    }
+};
+
+const allowedControls = [
+    'isMultiple',
+    'size',
+    'sx',
+    'menuSx',
+    'primaryColor',
+    'placeholder'
+];
+
+export const SingleSelect: StoryProps = {
+    parameters: {
+        controls: {
+            include: allowedControls
+        }
+    },
+    argTypes: { isMultiple: { control: 'select', options: [false] } },
+    args: {
+        isMultiple: false
+    },
+    render: props => <SelectStates {...props} />
+};
+
+export const MultiSelect: StoryProps = {
+    parameters: {
+        controls: {
+            include: allowedControls
+        }
+    },
+    argTypes: { isMultiple: { control: 'select', options: [true] } },
+    args: {
+        isMultiple: true,
+        value: []
+    },
+    render: props => <SelectStates {...props} />
+};

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,0 +1,228 @@
+import * as React from 'react';
+
+import { uniqBy } from 'lodash';
+
+import {
+    Autocomplete,
+    Chip,
+    TextField,
+    type AutocompleteProps,
+    type AutocompleteChangeReason,
+    type AutocompleteRenderGetTagProps,
+    type OutlinedInputProps,
+    type SxProps
+} from '@mui/material';
+
+import { SelectOption } from './SelectOption';
+
+import type { OptionsProps, OptionProps } from '@/interfaces';
+import { FIELD_SIZE, SELECT_OPTION_TYPE } from '@/Enum';
+
+type BaseAutocompleteProps = AutocompleteProps<
+    OptionProps,
+    boolean,
+    boolean,
+    false
+>;
+
+export interface SelectProps {
+    id: string;
+    label: string;
+    name: string;
+    options: OptionsProps;
+    value?: BaseAutocompleteProps['value'];
+    placeholder?: string;
+    inputValue?: string;
+    autoComplete?: string;
+    defaultValue?: BaseAutocompleteProps['defaultValue'];
+    disabledOptions?: OptionsProps;
+    fixedOptions?: OptionsProps;
+    hasError?: boolean;
+    helperText?: React.ReactNode;
+    inputProps?: Partial<OutlinedInputProps>;
+    isAutoFocusEnabled?: boolean;
+    isBlurOnSelect?: boolean;
+    isClearDisabled?: boolean;
+    isClearOnBlur?: boolean;
+    isDisabled?: boolean;
+    isFilterable?: boolean;
+    isFreeSolo?: boolean;
+    isMultiple?: boolean;
+    isPortalDisabled?: boolean;
+    isRequired?: boolean;
+    limitTags?: number;
+    optionType?: SELECT_OPTION_TYPE;
+    size?: FIELD_SIZE;
+    ListboxProps?: BaseAutocompleteProps['ListboxProps'];
+    sx?: SxProps;
+    onChange: NonNullable<BaseAutocompleteProps['onChange']>;
+    onBlur?: BaseAutocompleteProps['onBlur'];
+    onInputChange?: BaseAutocompleteProps['onInputChange'];
+    onNewClick?: () => void;
+    onOpen?: (e: React.SyntheticEvent) => void;
+}
+
+export const Select = ({
+    id = '',
+    label,
+    name,
+    options,
+    inputValue,
+    value,
+    placeholder = '',
+    autoComplete = 'off',
+    defaultValue = undefined,
+    disabledOptions = [],
+    fixedOptions = [],
+    hasError = false,
+    helperText = '',
+    inputProps = {},
+    isAutoFocusEnabled = false,
+    isBlurOnSelect = false,
+    isClearDisabled = false,
+    isClearOnBlur = true,
+    isDisabled = false,
+    isFilterable = true,
+    isMultiple = false,
+    isPortalDisabled = false,
+    isRequired = false,
+    limitTags = 1,
+    optionType = SELECT_OPTION_TYPE.CHECKBOX,
+    size = FIELD_SIZE.medium,
+    ListboxProps = {},
+    sx = {},
+    onChange,
+    onBlur,
+    onInputChange,
+    onNewClick,
+    onOpen
+}: SelectProps) => {
+    const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
+
+    const renderTags = React.useCallback(
+        (tags: OptionsProps, getTagProps: AutocompleteRenderGetTagProps) =>
+            tags.map((tag, index) => {
+                const { key, ...restProps } = getTagProps({ index });
+                const isFixed = fixedOptions.some(
+                    fixedOption => fixedOption.value === tag.value
+                );
+                return (
+                    <Chip
+                        key={key}
+                        label={tag.label}
+                        {...restProps}
+                        deleteIcon={isFixed ? <></> : undefined}
+                    />
+                );
+            }),
+        [fixedOptions]
+    );
+
+    const getDisabledOption = React.useCallback(
+        (option: OptionProps) =>
+            [...fixedOptions, ...disabledOptions].some(
+                element => element.value === option.value
+            ),
+        [disabledOptions, fixedOptions]
+    );
+
+    const handleDropdownOpen = React.useCallback(
+        (e: React.SyntheticEvent) => {
+            onOpen?.(e);
+            setIsDropdownOpen(true);
+        },
+        [onOpen]
+    );
+
+    const handleSelectChange = React.useCallback(
+        (
+            e: React.SyntheticEvent,
+            value: OptionProps | OptionsProps | null,
+            reason: AutocompleteChangeReason
+        ) => {
+            if (
+                fixedOptions.length &&
+                (reason === 'clear' || reason === 'removeOption') &&
+                Array.isArray(value)
+            ) {
+                const selectedOptions = uniqBy(
+                    [...fixedOptions, ...value],
+                    option => option.value
+                );
+                onChange(e, selectedOptions, reason);
+            } else {
+                onChange(e, value, reason);
+            }
+        },
+        [fixedOptions, onChange]
+    );
+
+    const handleNewClick = React.useCallback(() => {
+        setIsDropdownOpen(false);
+        onNewClick?.();
+    }, [onNewClick]);
+
+    return (
+        <Autocomplete
+            open={isDropdownOpen}
+            onOpen={handleDropdownOpen}
+            onClose={() => setIsDropdownOpen(false)}
+            sx={sx}
+            disablePortal={isPortalDisabled}
+            size={size}
+            autoComplete={false}
+            fullWidth
+            disableCloseOnSelect={isMultiple}
+            limitTags={limitTags}
+            id={id}
+            defaultValue={defaultValue}
+            disableClearable={isClearDisabled}
+            multiple={isMultiple}
+            options={options}
+            onInputChange={onInputChange}
+            onChange={handleSelectChange}
+            onBlur={onBlur}
+            getOptionLabel={option => option.label || ''}
+            value={value}
+            clearOnBlur={isClearOnBlur}
+            disabled={isDisabled}
+            ListboxProps={ListboxProps}
+            blurOnSelect={isBlurOnSelect}
+            renderTags={fixedOptions.length ? renderTags : undefined}
+            getOptionDisabled={getDisabledOption}
+            filterOptions={!isFilterable ? options => options : undefined}
+            renderOption={(liProps, option, { selected }) => (
+                <SelectOption
+                    key={option.value}
+                    liProps={liProps}
+                    option={option}
+                    optionType={optionType}
+                    isMultiple={isMultiple}
+                    isSelected={selected}
+                    isAutoFocusEnabled={isAutoFocusEnabled}
+                    onNewClick={handleNewClick}
+                />
+            )}
+            inputValue={inputValue}
+            renderInput={params => {
+                return (
+                    <TextField
+                        {...params}
+                        InputProps={{ ...params.InputProps, ...inputProps }}
+                        autoComplete={autoComplete}
+                        id={id}
+                        error={hasError}
+                        helperText={helperText}
+                        required={isRequired}
+                        placeholder={placeholder}
+                        fullWidth
+                        label={label}
+                        autoFocus={isAutoFocusEnabled}
+                        size={size}
+                        name={name}
+                    />
+                );
+            }}
+        />
+    );
+};

--- a/src/components/Select/SelectOption.tsx
+++ b/src/components/Select/SelectOption.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import { omit } from 'lodash';
+
+import { Box, Button, Checkbox, Radio, Typography } from '@mui/material';
+import { grey } from '@mui/material/colors';
+import { Plus } from '@phosphor-icons/react';
+
+import type { OptionProps } from '@/interfaces';
+import { COMMON_VALUE, SELECT_OPTION_TYPE } from '@/Enum';
+
+interface SelectOptionProps {
+    liProps: React.HTMLAttributes<HTMLLIElement>;
+    option: OptionProps;
+    optionType: SELECT_OPTION_TYPE;
+    isSelected: boolean;
+    isMultiple: boolean;
+    isAutoFocusEnabled: boolean;
+    onNewClick: VoidFunction;
+}
+
+export const SelectOption = ({
+    liProps,
+    option,
+    optionType,
+    isSelected,
+    isMultiple,
+    isAutoFocusEnabled,
+    onNewClick
+}: SelectOptionProps) => {
+    const props = omit(liProps, ['key']);
+
+    return (
+        <React.Fragment>
+            {option.value === COMMON_VALUE.NEW ? (
+                <Button
+                    fullWidth
+                    variant="text"
+                    onClick={onNewClick}
+                    sx={{
+                        px: 3,
+                        py: 1.5,
+                        justifyContent: 'start',
+                        fontWeight: 600
+                    }}
+                    startIcon={<Plus size={16} weight="bold" />}
+                >
+                    {option.label}
+                </Button>
+            ) : (
+                <li {...props}>
+                    {optionType === SELECT_OPTION_TYPE.CHECKBOX ? (
+                        isMultiple ? (
+                            <Checkbox
+                                size="small"
+                                sx={{ mr: 1 }}
+                                checked={isSelected}
+                                autoFocus={isAutoFocusEnabled}
+                            />
+                        ) : (
+                            <Radio checked={isSelected} />
+                        )
+                    ) : null}
+                    <Box sx={{ textWrap: 'wrap', wordBreak: 'break-all' }}>
+                        <Typography>{option.label}</Typography>
+                        {option.labelHelperText && (
+                            <Typography variant="caption" color={grey[600]}>
+                                {option.labelHelperText}
+                            </Typography>
+                        )}
+                    </Box>
+                </li>
+            )}
+        </React.Fragment>
+    );
+};

--- a/src/components/Select/index.ts
+++ b/src/components/Select/index.ts
@@ -1,0 +1,1 @@
+export * from './Select';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -26,3 +26,4 @@ export { CustomButton, type CustomButtonProps } from './CustomButton';
 export { CurrencyField, type CurrencyFieldProps } from './CurrencyField';
 export { TextArea, type TextAreaProps } from './TextArea';
 export { Select, type SelectProps } from './Select';
+export { AdaptiveSelect, type AdaptiveSelectProps } from './AdaptiveSelect';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -25,3 +25,4 @@ export { SearchBar, type SearchBarProps } from './SearchBar';
 export { CustomButton, type CustomButtonProps } from './CustomButton';
 export { CurrencyField, type CurrencyFieldProps } from './CurrencyField';
 export { TextArea, type TextAreaProps } from './TextArea';
+export { Select, type SelectProps } from './Select';

--- a/src/hooks/useFormUtils.ts
+++ b/src/hooks/useFormUtils.ts
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import type { OptionsProps } from '@/interfaces';
+
+interface GetSelectedOptionProps<TValue> {
+    options: OptionsProps;
+    fieldValue: TValue;
+}
+
+export const useFormUtils = () => {
+    const getSelectedOption = React.useCallback(
+        ({ options, fieldValue }: GetSelectedOptionProps<string>) => {
+            return options.find(option => option.value === fieldValue) || null;
+        },
+        []
+    );
+
+    const getMultiSelectedOptions = React.useCallback(
+        ({ options, fieldValue }: GetSelectedOptionProps<string[]>) => {
+            return fieldValue.reduce<OptionsProps>((selectedOptions, value) => {
+                const selectedOption = options.find(
+                    option => option.value === value
+                );
+                return selectedOption
+                    ? [...selectedOptions, selectedOption]
+                    : selectedOptions;
+            }, []);
+        },
+        []
+    );
+
+    return {
+        getSelectedOption,
+        getMultiSelectedOptions
+    };
+};


### PR DESCRIPTION
This PR adds `Select` and `AdaptiveSelect` component

## Features

- add `Select` component and storybook
- add `AdaptiveSelect` component and storybook

**Note: freeSolo support has not been added in `Select` component because it was taking time to integrate it in a type-safe manner. To be picked up later**

## Technical
- add `SELECT_OPTION_TYPE` and `COMMON_VALUE` enum

## Link
1. [Storybook Link](https://adaptive-select--666ac08efe69dd9c59a1e4c6.chromatic.com/?path=/docs/components-adaptiveselect--documentation)